### PR TITLE
fix(examples): //! Contract: headers on 152 helper .rs files — 100% coverage

### DIFF
--- a/examples/acceleration/acceleration_autotuner/types.rs
+++ b/examples/acceleration/acceleration_autotuner/types.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/acceleration/acceleration_cache_tiling/types.rs
+++ b/examples/acceleration/acceleration_cache_tiling/types.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/acceleration/acceleration_compression_benchmark/types.rs
+++ b/examples/acceleration/acceleration_compression_benchmark/types.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/acceleration/acceleration_kernel_fusion/types.rs
+++ b/examples/acceleration/acceleration_kernel_fusion/types.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/acceleration/acceleration_mmap_inference/tests.rs
+++ b/examples/acceleration/acceleration_mmap_inference/tests.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/acceleration/acceleration_mmap_inference/types.rs
+++ b/examples/acceleration/acceleration_mmap_inference/types.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/acceleration/acceleration_quantized_matmul/types.rs
+++ b/examples/acceleration/acceleration_quantized_matmul/types.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/advanced/ab_experiment/tests.rs
+++ b/examples/advanced/ab_experiment/tests.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/advanced/ab_experiment/types.rs
+++ b/examples/advanced/ab_experiment/types.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/advanced/cicd_model_pipeline/helpers.rs
+++ b/examples/advanced/cicd_model_pipeline/helpers.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/advanced/cicd_model_pipeline/types.rs
+++ b/examples/advanced/cicd_model_pipeline/types.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/advanced/clip_search/types.rs
+++ b/examples/advanced/clip_search/types.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/advanced/code_defect_oracle/helpers.rs
+++ b/examples/advanced/code_defect_oracle/helpers.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/advanced/code_defect_oracle/types.rs
+++ b/examples/advanced/code_defect_oracle/types.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/advanced/compliance_audit/helpers.rs
+++ b/examples/advanced/compliance_audit/helpers.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/advanced/compliance_audit/types.rs
+++ b/examples/advanced/compliance_audit/types.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/advanced/debug_fix_loop/helpers.rs
+++ b/examples/advanced/debug_fix_loop/helpers.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/advanced/debug_fix_loop/types.rs
+++ b/examples/advanced/debug_fix_loop/types.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/advanced/edge_anomaly_detection/helpers.rs
+++ b/examples/advanced/edge_anomaly_detection/helpers.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/advanced/edge_anomaly_detection/types.rs
+++ b/examples/advanced/edge_anomaly_detection/types.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/advanced/embedding_visualization/helpers.rs
+++ b/examples/advanced/embedding_visualization/helpers.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/advanced/embedding_visualization/types.rs
+++ b/examples/advanced/embedding_visualization/types.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/advanced/handwriting_recognition/helpers.rs
+++ b/examples/advanced/handwriting_recognition/helpers.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/advanced/handwriting_recognition/types.rs
+++ b/examples/advanced/handwriting_recognition/types.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/advanced/hierarchical_cache_benchmark/types.rs
+++ b/examples/advanced/hierarchical_cache_benchmark/types.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/advanced/image_classification/helpers.rs
+++ b/examples/advanced/image_classification/helpers.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/advanced/image_classification/types.rs
+++ b/examples/advanced/image_classification/types.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/advanced/model_inspection_scoring/helpers.rs
+++ b/examples/advanced/model_inspection_scoring/helpers.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/advanced/model_inspection_scoring/proptests.rs
+++ b/examples/advanced/model_inspection_scoring/proptests.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/advanced/model_inspection_scoring/tests.rs
+++ b/examples/advanced/model_inspection_scoring/tests.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/advanced/model_inspection_scoring/types.rs
+++ b/examples/advanced/model_inspection_scoring/types.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/advanced/model_showcase/tests.rs
+++ b/examples/advanced/model_showcase/tests.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/advanced/model_showcase/types.rs
+++ b/examples/advanced/model_showcase/types.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/advanced/online_training_defect/helpers.rs
+++ b/examples/advanced/online_training_defect/helpers.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/advanced/online_training_defect/types.rs
+++ b/examples/advanced/online_training_defect/types.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/advanced/quantization_quality_tradeoff/types.rs
+++ b/examples/advanced/quantization_quality_tradeoff/types.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/advanced/rag_pipeline/helpers.rs
+++ b/examples/advanced/rag_pipeline/helpers.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/advanced/rag_pipeline/types.rs
+++ b/examples/advanced/rag_pipeline/types.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/advanced/spanish_tutor/helpers.rs
+++ b/examples/advanced/spanish_tutor/helpers.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/advanced/spanish_tutor/types.rs
+++ b/examples/advanced/spanish_tutor/types.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/advanced/streaming_sentiment/helpers.rs
+++ b/examples/advanced/streaming_sentiment/helpers.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/advanced/streaming_sentiment/types.rs
+++ b/examples/advanced/streaming_sentiment/types.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/advanced/style_transfer/helpers.rs
+++ b/examples/advanced/style_transfer/helpers.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/advanced/voice_recognition/helpers.rs
+++ b/examples/advanced/voice_recognition/helpers.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/advanced/wasm_summarizer/helpers.rs
+++ b/examples/advanced/wasm_summarizer/helpers.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/advanced/wasm_summarizer/types.rs
+++ b/examples/advanced/wasm_summarizer/types.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/analysis/analysis_check/helpers.rs
+++ b/examples/analysis/analysis_check/helpers.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/analysis/analysis_check/types.rs
+++ b/examples/analysis/analysis_check/types.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/analysis/analysis_compare_hf/types.rs
+++ b/examples/analysis/analysis_compare_hf/types.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/analysis/analysis_flow/types.rs
+++ b/examples/analysis/analysis_flow/types.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/analysis/analysis_inspect/types.rs
+++ b/examples/analysis/analysis_inspect/types.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/analysis/analysis_lint/types.rs
+++ b/examples/analysis/analysis_lint/types.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/analysis/analysis_model_fingerprint/types.rs
+++ b/examples/analysis/analysis_model_fingerprint/types.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/analysis/analysis_oracle/types.rs
+++ b/examples/analysis/analysis_oracle/types.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/analysis/analysis_parity/types.rs
+++ b/examples/analysis/analysis_parity/types.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/analysis/analysis_probar/types.rs
+++ b/examples/analysis/analysis_probar/types.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/analysis/analysis_qa_capability/types.rs
+++ b/examples/analysis/analysis_qa_capability/types.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/analysis/analysis_qa_gates/types.rs
+++ b/examples/analysis/analysis_qa_gates/types.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/analysis/analysis_qualify/helpers.rs
+++ b/examples/analysis/analysis_qualify/helpers.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/analysis/analysis_qualify/types.rs
+++ b/examples/analysis/analysis_qualify/types.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/analysis/analysis_slice/types.rs
+++ b/examples/analysis/analysis_slice/types.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/analysis/analysis_tensors/types.rs
+++ b/examples/analysis/analysis_tensors/types.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/analysis/analysis_trace/types.rs
+++ b/examples/analysis/analysis_trace/types.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/analysis/analysis_validate/types.rs
+++ b/examples/analysis/analysis_validate/types.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/api/api_auth_middleware/types.rs
+++ b/examples/api/api_auth_middleware/types.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/chat/chat_injection_defense/types.rs
+++ b/examples/chat/chat_injection_defense/types.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/chat/chat_multi_format/types.rs
+++ b/examples/chat/chat_multi_format/types.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/cli/cli_apr_compile/helpers.rs
+++ b/examples/cli/cli_apr_compile/helpers.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/cli/cli_apr_decrypt/helpers.rs
+++ b/examples/cli/cli_apr_decrypt/helpers.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/cli/cli_apr_diagnose/helpers.rs
+++ b/examples/cli/cli_apr_diagnose/helpers.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/cli/cli_apr_diagnose/types.rs
+++ b/examples/cli/cli_apr_diagnose/types.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/cli/cli_apr_diff/helpers.rs
+++ b/examples/cli/cli_apr_diff/helpers.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/cli/cli_apr_ptx_map/helpers.rs
+++ b/examples/cli/cli_apr_ptx_map/helpers.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/cli/cli_apr_ptx_map/tests.rs
+++ b/examples/cli/cli_apr_ptx_map/tests.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/cli/cli_apr_ptx_map/types.rs
+++ b/examples/cli/cli_apr_ptx_map/types.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/cli/cli_apr_runs/helpers.rs
+++ b/examples/cli/cli_apr_runs/helpers.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/cli/cli_apr_runs/tests.rs
+++ b/examples/cli/cli_apr_runs/tests.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/cli/cli_apr_runs/types.rs
+++ b/examples/cli/cli_apr_runs/types.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/cli/cli_apr_tokenize/helpers.rs
+++ b/examples/cli/cli_apr_tokenize/helpers.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/cli/cli_apr_tokenize/tests.rs
+++ b/examples/cli/cli_apr_tokenize/tests.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/cli/cli_apr_tokenize/types.rs
+++ b/examples/cli/cli_apr_tokenize/types.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/cli/cli_apr_tui/types.rs
+++ b/examples/cli/cli_apr_tui/types.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/creation/create_apr_neural_network/helpers.rs
+++ b/examples/creation/create_apr_neural_network/helpers.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/creation/create_apr_neural_network/proptests.rs
+++ b/examples/creation/create_apr_neural_network/proptests.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/creation/create_apr_neural_network/tests.rs
+++ b/examples/creation/create_apr_neural_network/tests.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/creation/create_apr_neural_network/types.rs
+++ b/examples/creation/create_apr_neural_network/types.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/distillation/distill_attention_transfer/helpers.rs
+++ b/examples/distillation/distill_attention_transfer/helpers.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/distillation/distill_attention_transfer/tests.rs
+++ b/examples/distillation/distill_attention_transfer/tests.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/distillation/distill_attention_transfer/types.rs
+++ b/examples/distillation/distill_attention_transfer/types.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/distillation/distill_self_distillation/helpers.rs
+++ b/examples/distillation/distill_self_distillation/helpers.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/distillation/distill_self_distillation/proptests.rs
+++ b/examples/distillation/distill_self_distillation/proptests.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/distillation/distill_self_distillation/tests.rs
+++ b/examples/distillation/distill_self_distillation/tests.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/distributed/distributed_gossip_protocol/types.rs
+++ b/examples/distributed/distributed_gossip_protocol/types.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/distributed/distributed_model_sharding/types.rs
+++ b/examples/distributed/distributed_model_sharding/types.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/distributed/distributed_pipeline_parallel/types.rs
+++ b/examples/distributed/distributed_pipeline_parallel/types.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/distributed/distributed_ring_allreduce/types.rs
+++ b/examples/distributed/distributed_ring_allreduce/types.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/format/format_migration_pipeline/helpers.rs
+++ b/examples/format/format_migration_pipeline/helpers.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/format/format_publish/types.rs
+++ b/examples/format/format_publish/types.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/format/format_rosetta_convert/types.rs
+++ b/examples/format/format_rosetta_convert/types.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/gpu/flash_attention_inference/types.rs
+++ b/examples/gpu/flash_attention_inference/types.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/gpu/gpu_memory_pool/helpers.rs
+++ b/examples/gpu/gpu_memory_pool/helpers.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/gpu/gpu_ptx_analysis/helpers.rs
+++ b/examples/gpu/gpu_ptx_analysis/helpers.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/gpu/gpu_ptx_analysis/types.rs
+++ b/examples/gpu/gpu_ptx_analysis/types.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/gpu/gpu_vulkan_inference/types.rs
+++ b/examples/gpu/gpu_vulkan_inference/types.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/inference/chat_kv_cache/types.rs
+++ b/examples/inference/chat_kv_cache/types.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/inference/chat_tool_use/helpers.rs
+++ b/examples/inference/chat_tool_use/helpers.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/inference/chat_tool_use/types.rs
+++ b/examples/inference/chat_tool_use/types.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/inference/dynamic_batch_with_sla/types.rs
+++ b/examples/inference/dynamic_batch_with_sla/types.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/inference/ensemble_inference/types.rs
+++ b/examples/inference/ensemble_inference/types.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/inference/inference_apr_run/helpers.rs
+++ b/examples/inference/inference_apr_run/helpers.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/inference/inference_mmap_lazy_load/proptests.rs
+++ b/examples/inference/inference_mmap_lazy_load/proptests.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/inference/inference_mmap_lazy_load/tests.rs
+++ b/examples/inference/inference_mmap_lazy_load/tests.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/inference/inference_mmap_lazy_load/types.rs
+++ b/examples/inference/inference_mmap_lazy_load/types.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/monitoring/cbtop_headless/types.rs
+++ b/examples/monitoring/cbtop_headless/types.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/monitoring/inference_cost_tracking/types.rs
+++ b/examples/monitoring/inference_cost_tracking/types.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/monitoring/latency_histogram/helpers.rs
+++ b/examples/monitoring/latency_histogram/helpers.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/monitoring/latency_histogram/types.rs
+++ b/examples/monitoring/latency_histogram/types.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/monitoring/model_drift_detection/types.rs
+++ b/examples/monitoring/model_drift_detection/types.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/monitoring/monitoring_memory_profiler/types.rs
+++ b/examples/monitoring/monitoring_memory_profiler/types.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/optimize/finetune_plan_vram/types.rs
+++ b/examples/optimize/finetune_plan_vram/types.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/optimize/optimize_full_pipeline/types.rs
+++ b/examples/optimize/optimize_full_pipeline/types.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/optimize/optimize_tune/types.rs
+++ b/examples/optimize/optimize_tune/types.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/registry/registry_model_versioning/helpers.rs
+++ b/examples/registry/registry_model_versioning/helpers.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/registry/registry_model_versioning/types.rs
+++ b/examples/registry/registry_model_versioning/types.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/serve/http_model_server/types.rs
+++ b/examples/serve/http_model_server/types.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/serve/model_ab_testing/types.rs
+++ b/examples/serve/model_ab_testing/types.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/serve/model_canary_deploy/types.rs
+++ b/examples/serve/model_canary_deploy/types.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/serve/model_rate_limiter/helpers.rs
+++ b/examples/serve/model_rate_limiter/helpers.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/serve/model_rate_limiter/types.rs
+++ b/examples/serve/model_rate_limiter/types.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/serve/model_selection_router/types.rs
+++ b/examples/serve/model_selection_router/types.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/serverless/serverless_model_warmup/helpers.rs
+++ b/examples/serverless/serverless_model_warmup/helpers.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/serverless/serverless_model_warmup/proptests.rs
+++ b/examples/serverless/serverless_model_warmup/proptests.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/serverless/serverless_model_warmup/tests.rs
+++ b/examples/serverless/serverless_model_warmup/tests.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/simd/simd_avx_vnni_int8_inference/types.rs
+++ b/examples/simd/simd_avx_vnni_int8_inference/types.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/simd/trueno_simd_ops/types.rs
+++ b/examples/simd/trueno_simd_ops/types.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/speech/speech_diarization/types.rs
+++ b/examples/speech/speech_diarization/types.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/speech/speech_multilingual/types.rs
+++ b/examples/speech/speech_multilingual/types.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/speech/speech_vad/types.rs
+++ b/examples/speech/speech_vad/types.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/speech/whisper_streaming/types.rs
+++ b/examples/speech/whisper_streaming/types.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/training/autograd_backprop_viz/types.rs
+++ b/examples/training/autograd_backprop_viz/types.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/training/autograd_custom_ops/tests.rs
+++ b/examples/training/autograd_custom_ops/tests.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/training/autograd_custom_ops/types.rs
+++ b/examples/training/autograd_custom_ops/types.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/training/autograd_gradient_clipping/helpers.rs
+++ b/examples/training/autograd_gradient_clipping/helpers.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/training/data_preprocessing/types.rs
+++ b/examples/training/data_preprocessing/types.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/training/entrenar_autograd_training/types.rs
+++ b/examples/training/entrenar_autograd_training/types.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/training/few_shot_finetune/types.rs
+++ b/examples/training/few_shot_finetune/types.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/training/gradient_accumulation/types.rs
+++ b/examples/training/gradient_accumulation/types.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/training/hyperparameter_sweep/types.rs
+++ b/examples/training/hyperparameter_sweep/types.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/training/learning_rate_schedule/types.rs
+++ b/examples/training/learning_rate_schedule/types.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/training/mixed_precision_training/types.rs
+++ b/examples/training/mixed_precision_training/types.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/wasm/wasm_model_loader/helpers.rs
+++ b/examples/wasm/wasm_model_loader/helpers.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,

--- a/examples/wasm/wasm_model_loader/types.rs
+++ b/examples/wasm/wasm_model_loader/types.rs
@@ -1,3 +1,6 @@
+//! Support module for the sibling `main.rs` recipe.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
 #![allow(
     dead_code,
     unused_imports,


### PR DESCRIPTION
## Summary

Invariant B's contract-coverage claim in `docs/specifications/components/quality-gates.md` was previously denominator-clarified to "219 Cargo `[[example]]` entries" (all had headers) because helper files — `types.rs`, `helpers.rs`, `tests.rs` living alongside `main.rs` in split-directory recipes — did not. That left 152 of 377 total recipe .rs files uncovered (59.7%).

This PR closes the gap.

## What changed

Every helper now carries a 3-line doc block at the very top of the file, before any `#![allow]` inner attributes:

```rust
//! Support module for the sibling `main.rs` recipe.
//!
//! Contract: contracts/recipe-iiur-v1.yaml (inherited from main.rs — Invariant B)
```

Mechanical change — no semantic edits, no logic change, no `Cargo.toml` edit.

## Verification

```bash
find examples/ -name '*.rs' | xargs grep -L '^//! Contract:'  # -> 0 files
find examples/ -name '*.rs' | wc -l                           # -> 377 files
cargo check --all-targets                                     # -> OK
cargo clippy --all-targets -- -D warnings                     # -> rc 0
cargo fmt --all --check                                       # -> OK
```

With this landed, the spec's Invariant B claim becomes true without the denominator-clarification caveat: **377 / 377 recipe .rs files carry a `//! Contract:` header (100%)**.

## Test plan

- [ ] CI passes
- [ ] No semantic changes — spot-check random helper file diffs (each should be +3 lines at top)

(Refs PMAT-038)

🤖 Generated with [Claude Code](https://claude.com/claude-code)