### PR TITLE
feat(spec): Invariant F — Variant Depth (≥3 recipes per subcommand)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -205,6 +205,33 @@ cli-parity: ## Verify every apr subcommand has ≥1 cookbook recipe (F-CLIPARITY
 	fi
 	@echo "✅ CLI parity: all $$( wc -l < /tmp/apr-subs.txt | tr -d ' ') subcommands have ≥1 recipe"
 
+variant-depth: ## Invariant F: verify every apr subcommand has ≥3 cookbook recipes (F-VARIANT-DEPTH-001)
+	@echo "🔁 Checking variant-depth (≥3 recipes per subcommand)..."
+	@apr --help 2>&1 | awk '/^  [a-z]/ {print $$1}' | sort -u | grep -v '^help$$' > /tmp/apr-subs.txt
+	@grep -rhoiE 'CLI [Ee]quivalent[*: ]+`?apr [a-z][a-z-]+' examples/ 2>/dev/null \
+		| grep -oiE 'apr [a-z][a-z-]+' | awk '{print tolower($$2)}' | sort | uniq -c \
+		| awk '{printf "%-25s %s\n", $$2, $$1}' > /tmp/sub-counts.txt
+	@TOTAL=$$(wc -l < /tmp/apr-subs.txt); \
+	OK=$$(while read sub; do \
+		count=$$(awk -v s="$$sub" '$$1==s{print $$2; exit}' /tmp/sub-counts.txt || echo 0); \
+		count=$${count:-0}; \
+		if [ "$$count" -ge 3 ]; then echo "$$sub"; fi; \
+	done < /tmp/apr-subs.txt | wc -l); \
+	SHORT=$$(while read sub; do \
+		count=$$(awk -v s="$$sub" '$$1==s{print $$2; exit}' /tmp/sub-counts.txt || echo 0); \
+		count=$${count:-0}; \
+		if [ "$$count" -lt 3 ]; then printf "    apr %-20s  (%d recipes)\n" "$$sub" "$$count"; fi; \
+	done < /tmp/apr-subs.txt); \
+	printf "  Subcommands:   %3d\n  At ≥3 depth:   %3d\n  Coverage:      %d%%\n" "$$TOTAL" "$$OK" "$$((100*OK/TOTAL))"; \
+	if [ -n "$$SHORT" ]; then \
+		echo "⚠️  Below variant-depth target (<3 recipes — TARGET, not yet ENFORCED):"; \
+		echo "$$SHORT"; \
+		echo "    See: docs/specifications/components/quality-gates.md#invariant-f"; \
+		echo "    Backlog: PMAT-049 / -050 / -051"; \
+	fi
+	@# TARGET gate: don't fail CI yet. Change `exit 0` → `exit 1` when ENFORCED.
+	@exit 0
+
 variant-coverage: ## Report per-subcommand flag/variant coverage
 	@echo "📊 Per-subcommand variant coverage:"
 	@printf "  %-15s %8s %8s %6s\n" "SUBCOMMAND" "FLAGS" "RECIPES" "COV%"

--- a/docs/specifications/apr-cookbook.md
+++ b/docs/specifications/apr-cookbook.md
@@ -312,19 +312,19 @@ The following claims were asserted in prior spec versions but are **removed** fr
 
 All surviving claims (F2 + N1–N4) are backed by provable-contracts YAML in `contracts/` (11 files total). Every YAML parses and validates in-process via `cargo test --test contracts`, which replaces the prior external `pv validate` dependency. 219/219 cargo `[[example]]` recipes reference ≥1 contract via `//! Contract:` header (Invariant B). Contract inventory: see [Quality Gates](components/quality-gates.md).
 
-## Five Coverage Invariants
+## Six Coverage Invariants
 
-The spec defines five coverage invariants. Each has a formal definition, a `make` target for enforcement, and a measured baseline. All five are enforced.
+The spec defines six coverage invariants. Each has a formal definition, a `make` target for enforcement, and a measured baseline.
 
 ### Invariant A — CLI Recipe Parity (F-CLIPARITY-001) — ENFORCED
 
-Every one of the **57 non-help apr-cli subcommands** has ≥1 cookbook recipe.
+Every one of the **66 non-help apr-cli subcommands** (APR-MONO v0.31.2) has ≥1 cookbook recipe.
 
 ```
 ∀ s ∈ apr.subcommands \ {help}: ∃ r ∈ recipes: r.cli_equivalent = s
 ```
 
-**Baseline (2026-04-22)**: 57/57 = 100%. **Gate**: `make cli-parity` (exits non-zero on regression).
+**Baseline (2026-04-22)**: 56/66 = 85% (10 subcommands added by APR-MONO v0.31.2 still uncovered — see PMAT-049). **Gate**: `make cli-parity` (exits non-zero on regression).
 
 ### Invariant B — Recipe Contract Grade (F-CONTRACT-GRADE-001) — ENFORCED
 
@@ -386,6 +386,19 @@ Every documentation artifact in the repo — `README.md`, `CLAUDE.md`, mdbook ch
   pv lint(c) = PASS
   pmat validate-readme(d) ⊨ {unverified = 0, contradictions = 0}
 ```
+
+### Invariant F — Variant Depth (F-VARIANT-DEPTH-001) — TARGET
+
+Every apr-cli subcommand must have **≥3 distinct cookbook recipes** demonstrating different variants (different flag values, input shapes, deployment targets, or workflows). Single-example coverage is necessary (Invariant A) but not sufficient — real users need multiple worked examples per subcommand to learn idiomatic usage.
+
+```
+∀ s ∈ apr.subcommands \ {help}:
+  |{ r ∈ recipes : r.cli_equivalent = s }| ≥ 3
+```
+
+**Rationale**: A single recipe demonstrates that a subcommand exists; three demonstrate the *variance* (happy path, edge case, composition). This maps directly to Toyota *kata* — three repetitions make the pattern concrete.
+
+**Baseline (2026-04-22)**: 8/66 = 12% (only `prune`, `merge`, `finetune`, `distill`, `chat`, `rosetta`, `export`, `convert` currently meet the bar). **Gate**: `make variant-depth` — **TARGET**, not yet enforced (raising it to ENFORCED requires ≥128 new recipes; see PMAT-049/050/051 backlog).
 
 **Baseline (2026-04-22)**: 264/267 = **98.9%**. `make docs-validate` covers `README.md`, `CLAUDE.md`, `docs/specifications/**/*.md`, and `book/src/**/*.md`. 3 excluded: `CHANGELOG.md`, `deep-context.md` (generated), `docs/specifications-advanced-demos.md` (orphan). **Gate**: `make docs-validate` — **ENFORCED**.
 

--- a/docs/specifications/components/quality-gates.md
+++ b/docs/specifications/components/quality-gates.md
@@ -367,19 +367,19 @@ A `make docs-validate` target chains these. Docs validation is a **mandatory pre
 
 ---
 
-## Five Coverage Invariants
+## Six Coverage Invariants
 
-These are the **master quality gates** for the cookbook. All five invariants are measured; A–E are enforced via `make` targets.
+These are the **master quality gates** for the cookbook. A–E are enforced via `make` targets. F is currently TARGET (aspirational) pending backlog work.
 
 ### Invariant A — CLI Recipe Parity (F-CLIPARITY-001) — ENFORCED
 
-Every apr-cli subcommand (excluding `help`) must have ≥1 cookbook recipe.
+Every apr-cli subcommand (excluding `help`) must have ≥1 cookbook recipe. APR-MONO v0.31.2 exposes **66 subcommands** (up from 57 in v4.0 — see `apr --help`).
 
 ```
 ∀ s ∈ apr.subcommands \ {help}: ∃ r ∈ recipes: r.cli_equivalent = s
 ```
 
-**Baseline**: 57/57 = **100%**. **Gate**: `make cli-parity` (exits non-zero on regression).
+**Baseline**: 56/66 = **85%** (10 new v0.31.2 subcommands uncovered — see PMAT-049). **Gate**: `make cli-parity` (exits non-zero on regression).
 
 ### Invariant B — Recipe Contract Grade (F-CONTRACT-GRADE-001) — ENFORCED
 
@@ -443,9 +443,37 @@ Every documentation artifact — `README.md`, `CLAUDE.md`, mdbook chapters, spec
 
 **Baseline**: 264/267 = **98.9%**. `make docs-validate` covers `README.md`, `CLAUDE.md`, `docs/specifications/**/*.md`, `book/src/**/*.md`. **Gate**: `make docs-validate` — **ENFORCED**.
 
+### Invariant F — Variant Depth (F-VARIANT-DEPTH-001) — TARGET
+
+Every apr-cli subcommand must have **≥3 distinct cookbook recipes**. Single-example coverage is necessary (Invariant A) but not sufficient — learners need multiple worked examples per subcommand to internalize idiomatic usage. Three maps to Toyota *kata*: happy path, edge case, composition.
+
+```
+∀ s ∈ apr.subcommands \ {help}:
+  |{ r ∈ recipes : r.cli_equivalent = s }| ≥ 3
+```
+
+**Baseline (2026-04-22)**: 8/66 = **12%** at ≥3; 48/66 at exactly 1–2; 10/66 at 0. **Gate**: `make variant-depth` — **TARGET**, not ENFORCED (reaching ENFORCED requires ≥128 new recipes; backlog is PMAT-049 / -050 / -051).
+
+#### Current ≥3-coverage subcommands
+
+| Subcommand | Count | Recipes |
+|------------|-------|---------|
+| `prune` | 5 | magnitude, structured, depth, wanda, gradual_schedule |
+| `merge` | 5 | average, weighted, slerp, ties, dare (+ hierarchical) |
+| `finetune` | 5 | lora, qlora, merge_adapter, plan_vram |
+| `distill` | 4 | standard_kl, progressive, ensemble, checkpoint |
+| `chat` | 4 | chatml, llama2, mistral, multi-format |
+| `rosetta` | 3 | convert, chain, verify |
+| `export` | 3 | safetensors, gguf, batch |
+| `convert` | 3 | safetensors↔apr, gguf→apr, apr→gguf |
+
+#### Zero-coverage (PMAT-049 blocks)
+
+10 APR-MONO v0.31.2 subcommands still have no recipe: `awq-lint`, `dry-sampling-lint`, `gbnf-lint`, `mcp`, `ollama-chat-lint`, `oom-lint`, `pretrain`, `registry`, `tool-use-lint`, `validate-manifest`. Each needs 3 recipes per Invariant F.
+
 ### Variant definition
 
-A **variant** is a distinct (subcommand, flag, value) triple exposed in `apr <sub> --help`. For example, `apr run` has ~20 flags; `apr merge --strategy` has 5 values (average, weighted, slerp, ties, dare), yielding 5 variants just for `--strategy`. Over 57 subcommands, apr-cli exposes ~468 distinct flag variants.
+A **variant** is a distinct (subcommand, flag, value) triple exposed in `apr <sub> --help`. For example, `apr run` has ~20 flags; `apr merge --strategy` has 5 values (average, weighted, slerp, ties, dare), yielding 5 variants just for `--strategy`. Over 66 subcommands, apr-cli exposes ~500 distinct flag variants.
 
 ### Recipe doc-comment contract
 
@@ -475,12 +503,13 @@ The `make cli-parity` regex matches all of:
 
 | Dimension | Baseline | Target | Gate | Status |
 |-----------|----------|--------|------|--------|
-| Subcommands with ≥1 recipe | 57/57 (100%) | 57/57 | `make cli-parity` | **ENFORCED** |
+| Subcommands with ≥1 recipe | 56/66 (85%) | 66/66 | `make cli-parity` | **ENFORCED** |
+| Subcommands with ≥3 recipes | 8/66 (12%) | 66/66 | `make variant-depth` | **TARGET** |
 | Recipes with contract reference | 219/219 (100%) | 219/219 | `make contract-grade` | **ENFORCED** |
 | Recipes with all format variants | 219/219 (100%) | 100% applicable | `make format-coverage` | **ENFORCED** |
 | Recipes with arXiv/DOI citation | 219/219 (100%) | 219/219 | `make citation-check` | **ENFORCED** |
 | Docs validated by contract | 264/267 (98.9%) | 267/267 | `make docs-validate` | **ENFORCED** |
-| Flag variants | ~468 | ~468 | `make variant-coverage` | measured |
+| Flag variants | ~500 | ~500 | `make variant-coverage` | measured |
 | Contracts with Lean proof ≥ L2 | 0/11 | 80%+ | `pv lean-status` | TARGET |
 
 ### Pre-commit enforcement
@@ -491,5 +520,6 @@ make contract-grade          # Invariant B: every recipe has grade-A contract
 make format-coverage         # Invariant C: APR/GGUF/SafeTensors variants
 make citation-check          # Invariant D: arXiv citation per recipe
 make docs-validate           # Invariant E: docs contract coverage
+make variant-depth           # Invariant F: ≥3 recipes per subcommand (TARGET)
 make variant-coverage        # Detailed per-subcommand flag matrix
 ```


### PR DESCRIPTION
## Summary

APR-MONO v0.31.2 exposes 66 apr-cli subcommands (was 57 in v4.0). Invariant A says every subcommand must have ≥1 cookbook recipe — that proves existence but not usability. This adds **Invariant F: ≥3 recipes per subcommand** (Toyota *kata*: happy path, edge case, composition).

## Changes

- `docs/specifications/apr-cookbook.md` — invariant count 5 → 6; Invariant A baseline updated 57/57 → 56/66 (APR-MONO added 10 uncovered subs); new Invariant F section.
- `docs/specifications/components/quality-gates.md` — matching section with per-subcommand table of current ≥3-coverage; zero-coverage list with backlog pointer.
- `Makefile` — new `make variant-depth` target (TARGET, not ENFORCED — reports but doesn't fail CI).

## Baseline (current main)

```
Subcommands:    66
At ≥3 depth:     8    (prune, merge, finetune, distill, chat, rosetta, export, convert)
Coverage:       12%
```

58 subcommands below target. ~128 new recipes needed to enforce.

## Backlog (split for incremental delivery)

| Ticket | Scope | Count |
|--------|-------|-------|
| PMAT-049 (high) | 10 zero-coverage subs × 3 recipes | 30 new |
| PMAT-050 (medium) | ~40 single-coverage × 2 | ~80 new |
| PMAT-051 (low) | ~10 dual-coverage × 1 | ~10 new |

Landing all three → Invariant F ENFORCED at 66/66.

## NOT in this PR

- No new example recipes (that's PMAT-049+).
- `cli-parity` still flags 10 missing-from-monorepo subs (existing gate, not introduced here).

## Test plan

- [ ] `make variant-depth` runs, reports 8/66, exits 0 (TARGET — by design doesn't fail CI yet)
- [ ] Spec links resolve
- [ ] CI passes

(Refs PMAT-049, PMAT-050, PMAT-051)

🤖 Generated with [Claude Code](https://claude.com/claude-code)