### PR TITLE
feat(examples): 4 recipes lift compare-hf/qa/tensors/run to ≥3 (variant-depth 18→22)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1162,3 +1162,20 @@ path = "examples/format/validate_manifest_sha_mismatch.rs"
 [[example]]
 name = "validate_manifest_live_check"
 path = "examples/format/validate_manifest_live_check.rs"
+
+# Category: Analysis + Inference additions (PMAT-051 — Invariant F)
+[[example]]
+name = "analysis_compare_hf_threshold"
+path = "examples/analysis/analysis_compare_hf_threshold.rs"
+
+[[example]]
+name = "analysis_qa_report"
+path = "examples/analysis/analysis_qa_report.rs"
+
+[[example]]
+name = "analysis_tensors_stats"
+path = "examples/analysis/analysis_tensors_stats.rs"
+
+[[example]]
+name = "inference_run_temperature_sweep"
+path = "examples/inference/inference_run_temperature_sweep.rs"

--- a/examples/analysis/analysis_compare_hf_threshold.rs
+++ b/examples/analysis/analysis_compare_hf_threshold.rs
@@ -1,0 +1,291 @@
+//! # Recipe: compare-hf Threshold Sweep
+//!
+//! **Category**: analysis
+//! **CLI Equivalent**: `apr compare-hf model.apr --repo my-org/my-model --threshold <tau>`
+//! **Isolation Level**: Full
+//! **Idempotency**: Guaranteed
+//! **Dependencies**: apr-cookbook (default features)
+//! Contract: contracts/recipe-iiur-v1.yaml
+//!
+//! ## QA Checklist
+//! 1. [x] `cargo run --example analysis_compare_hf_threshold` exits 0
+//! 2. [x] `cargo test --example analysis_compare_hf_threshold` passes
+//! 3. [x] Deterministic output (same seed → same mismatch counts)
+//! 4. [x] No temp files leaked (RecipeContext tempdir)
+//! 5. [x] No `unwrap()` in main logic
+//! 6. [x] Clippy clean under `-D warnings`
+//! 7. [x] Threshold sweep is monotone (stricter τ → ≥ mismatches)
+//!
+//! ## Learning Objective
+//! Demonstrates how the `--threshold` knob on `apr compare-hf` trades off
+//! false-positive mismatches versus silent drift. We run the full APR-vs-HF
+//! comparison four times at τ ∈ {1e-3, 1e-4, 1e-5, 1e-6} with fixed injected
+//! noise, then chart the mismatched-tensor count. The sweep is monotone
+//! non-decreasing as τ tightens — a foundational property engineers rely on
+//! when picking a release-blocking threshold in CI.
+//!
+//! ## Run Command
+//! ```bash
+//! cargo run --example analysis_compare_hf_threshold
+//! ```
+//!
+//! ## Format Variants
+//! ```bash
+//! apr compare-hf model.apr          --threshold 1e-5   # APR ↔ HF SafeTensors (tight)
+//! apr compare-hf model.apr          --threshold 1e-3   # APR ↔ HF SafeTensors (loose)
+//! apr compare-hf model.gguf         --threshold 1e-5   # GGUF ↔ HF
+//! ```
+//!
+//! ## References
+//! - Dettmers, T. et al. (2022). *LLM.int8(): 8-bit Matrix Multiplication for Transformers at Scale*. NeurIPS. arXiv:2208.07339
+
+use apr_cookbook::prelude::*;
+use apr_cookbook::{CookbookError, Result};
+use rand::Rng;
+
+/// Per-tensor comparison outcome at a fixed threshold.
+#[derive(Debug, Clone, PartialEq)]
+pub struct TensorOutcome {
+    pub name: String,
+    pub max_abs_err: f64,
+    pub mismatched: bool,
+}
+
+/// Sweep result at a single threshold τ.
+#[derive(Debug, Clone, PartialEq)]
+pub struct SweepPoint {
+    pub threshold: f64,
+    pub total: usize,
+    pub mismatched: usize,
+}
+
+/// Build `n` synthetic tensor error magnitudes in a deterministic spread.
+///
+/// Errors range from near-zero (clean tensors) to larger deliberate drift in
+/// a handful — simulating a real APR vs HF comparison where most tensors
+/// match bit-for-bit but a few have accumulated float error.
+pub fn synthesize_errors(rng: &mut impl Rng, n: usize) -> Vec<TensorOutcome> {
+    (0..n)
+        .map(|i| {
+            // Deterministic magnitude spread: most tiny, a few medium, one or two large.
+            let mag_exp: f64 = match i {
+                0..=2 => -8.0 + rng.gen::<f64>() * 1.0, // 1e-8..1e-7 (clean)
+                3..=5 => -6.0 + rng.gen::<f64>() * 1.0, // 1e-6..1e-5 (borderline)
+                6..=7 => -4.5 + rng.gen::<f64>() * 0.5, // 3e-5..1e-4 (medium)
+                _ => -3.5 + rng.gen::<f64>() * 0.5,     // 3e-4..1e-3 (large)
+            };
+            let mag = 10.0_f64.powf(mag_exp);
+            TensorOutcome {
+                name: format!("tensor_{i:02}"),
+                max_abs_err: mag,
+                mismatched: false,
+            }
+        })
+        .collect()
+}
+
+/// Apply a threshold τ — mark every tensor with `max_abs_err > τ` as mismatched.
+#[must_use]
+pub fn apply_threshold(tensors: &[TensorOutcome], threshold: f64) -> SweepPoint {
+    let mut mismatched = 0;
+    for t in tensors {
+        if t.max_abs_err > threshold {
+            mismatched += 1;
+        }
+    }
+    SweepPoint {
+        threshold,
+        total: tensors.len(),
+        mismatched,
+    }
+}
+
+/// Run the full sweep across a list of thresholds.
+#[must_use]
+pub fn run_sweep(tensors: &[TensorOutcome], thresholds: &[f64]) -> Vec<SweepPoint> {
+    thresholds
+        .iter()
+        .map(|&t| apply_threshold(tensors, t))
+        .collect()
+}
+
+/// Render a simple bar chart of mismatched-tensor counts per threshold.
+#[must_use]
+pub fn render_chart(sweep: &[SweepPoint]) -> String {
+    let mut s = String::new();
+    s.push_str("  τ          mismatched  chart\n");
+    s.push_str("  ---------  ----------  ----------------\n");
+    let max_count = sweep.iter().map(|p| p.mismatched).max().unwrap_or(0).max(1);
+    for p in sweep {
+        let bar_len = p.mismatched * 20 / max_count;
+        let bar: String = "#".repeat(bar_len);
+        s.push_str(&format!(
+            "  {:<9.0e}  {:>10}  {}\n",
+            p.threshold, p.mismatched, bar
+        ));
+    }
+    s
+}
+
+fn main() -> Result<()> {
+    let mut ctx = RecipeContext::new("analysis_compare_hf_threshold")?;
+    println!("=== Recipe: {} ===\n", ctx.name());
+
+    // --- Section 1: Synthesize tensor-error spread -------------------------
+    let n_tensors = 10;
+    let tensors = synthesize_errors(ctx.rng(), n_tensors);
+    println!("Synthesized {n_tensors} tensor error magnitudes:");
+    for t in &tensors {
+        println!("  {:<12} max_abs_err = {:.2e}", t.name, t.max_abs_err);
+    }
+    println!();
+
+    // --- Section 2: Sweep four canonical thresholds ------------------------
+    let thresholds = [1e-3, 1e-4, 1e-5, 1e-6];
+    let sweep = run_sweep(&tensors, &thresholds);
+
+    println!("--- Threshold Sweep ---");
+    println!("{}", render_chart(&sweep));
+
+    // --- Section 3: Assert monotone non-decreasing as τ tightens ----------
+    let mut prev = 0usize;
+    for p in &sweep {
+        if p.mismatched < prev {
+            return Err(CookbookError::invalid_format(format!(
+                "sweep not monotone at τ={:.0e}: {} < prev {}",
+                p.threshold, p.mismatched, prev
+            )));
+        }
+        prev = p.mismatched;
+    }
+    println!("✓ Sweep is monotone: stricter τ → more (or equal) mismatches\n");
+
+    // --- Section 4: Persist sweep JSON for CI dashboards ------------------
+    let summary = serde_json::json!({
+        "schema_version": 1,
+        "sub": "compare-hf",
+        "total_tensors": n_tensors,
+        "points": sweep.iter().map(|p| serde_json::json!({
+            "threshold": p.threshold,
+            "mismatched": p.mismatched,
+            "total": p.total,
+        })).collect::<Vec<_>>(),
+    });
+    let out_path = ctx.path("compare_hf_sweep.json");
+    std::fs::write(
+        &out_path,
+        serde_json::to_vec_pretty(&summary)
+            .map_err(|e| CookbookError::Serialization(e.to_string()))?,
+    )?;
+    println!("Sweep JSON: {}\n", out_path.display());
+
+    // --- Section 5: Metrics ------------------------------------------------
+    let tightest = sweep.last().map_or(0, |p| p.mismatched);
+    let loosest = sweep.first().map_or(0, |p| p.mismatched);
+    ctx.record_metric("tensors_total", n_tensors as i64);
+    ctx.record_metric("mismatched_tightest", tightest as i64);
+    ctx.record_metric("mismatched_loosest", loosest as i64);
+    ctx.record_string_metric(
+        "verdict",
+        if tightest >= loosest {
+            "MONOTONE"
+        } else {
+            "BROKEN"
+        },
+    );
+
+    ctx.report()?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rand::SeedableRng;
+
+    fn test_rng() -> rand::rngs::StdRng {
+        rand::rngs::StdRng::seed_from_u64(42)
+    }
+
+    #[test]
+    fn test_synthesize_errors_produces_n() {
+        let mut rng = test_rng();
+        let xs = synthesize_errors(&mut rng, 10);
+        assert_eq!(xs.len(), 10);
+        for x in &xs {
+            assert!(x.max_abs_err > 0.0);
+            assert!(x.max_abs_err.is_finite());
+        }
+    }
+
+    #[test]
+    fn test_apply_threshold_counts_correctly() {
+        let tensors = vec![
+            TensorOutcome {
+                name: "a".into(),
+                max_abs_err: 1e-2,
+                mismatched: false,
+            },
+            TensorOutcome {
+                name: "b".into(),
+                max_abs_err: 1e-6,
+                mismatched: false,
+            },
+            TensorOutcome {
+                name: "c".into(),
+                max_abs_err: 1e-8,
+                mismatched: false,
+            },
+        ];
+        let p = apply_threshold(&tensors, 1e-5);
+        // 1e-2 > 1e-5 → mismatched; 1e-6, 1e-8 ≤ 1e-5 → match.
+        assert_eq!(p.mismatched, 1);
+        assert_eq!(p.total, 3);
+    }
+
+    #[test]
+    fn test_sweep_is_monotone_non_decreasing() {
+        let mut rng = test_rng();
+        let tensors = synthesize_errors(&mut rng, 10);
+        let thresholds = [1e-3, 1e-4, 1e-5, 1e-6];
+        let sweep = run_sweep(&tensors, &thresholds);
+        let mut prev = 0usize;
+        for p in &sweep {
+            assert!(
+                p.mismatched >= prev,
+                "not monotone at τ={:.0e}: {} < {}",
+                p.threshold,
+                p.mismatched,
+                prev
+            );
+            prev = p.mismatched;
+        }
+    }
+
+    #[test]
+    fn test_render_chart_includes_header_and_rows() {
+        let sweep = vec![
+            SweepPoint {
+                threshold: 1e-3,
+                total: 10,
+                mismatched: 2,
+            },
+            SweepPoint {
+                threshold: 1e-5,
+                total: 10,
+                mismatched: 6,
+            },
+        ];
+        let chart = render_chart(&sweep);
+        assert!(chart.contains("mismatched"));
+        assert!(chart.contains("1e-3"));
+        assert!(chart.contains("1e-5"));
+    }
+
+    #[test]
+    fn test_deterministic_with_same_seed() {
+        let xs1 = synthesize_errors(&mut test_rng(), 10);
+        let xs2 = synthesize_errors(&mut test_rng(), 10);
+        assert_eq!(xs1, xs2);
+    }
+}

--- a/examples/analysis/analysis_qa_report.rs
+++ b/examples/analysis/analysis_qa_report.rs
@@ -1,0 +1,427 @@
+//! # Recipe: QA Aggregate Report Across Models
+//!
+//! **Category**: analysis
+//! **CLI Equivalent**: `apr qa <model.apr> --report markdown`
+//! **Isolation Level**: Full
+//! **Idempotency**: Guaranteed
+//! **Dependencies**: apr-cookbook (default features)
+//! Contract: contracts/recipe-iiur-v1.yaml
+//!
+//! ## QA Checklist
+//! 1. [x] `cargo run --example analysis_qa_report` exits 0
+//! 2. [x] `cargo test --example analysis_qa_report` passes
+//! 3. [x] Deterministic output (same seed → same gate matrix)
+//! 4. [x] No temp files leaked (RecipeContext tempdir)
+//! 5. [x] No `unwrap()` in main logic
+//! 6. [x] Clippy clean under `-D warnings`
+//! 7. [x] Markdown report is valid GFM table (row/column alignment)
+//!
+//! ## Learning Objective
+//! Demonstrates how to aggregate `apr qa` across N candidate models in a CI
+//! pipeline — run the 6 canonical gates (format, integrity, performance,
+//! size, accuracy, security) on three deterministic synthetic models, then
+//! render a pass/fail matrix as a GitHub-flavoured-Markdown table. Teaches
+//! the operational pattern Sculley et al. call "monitoring beyond model
+//! accuracy" — the gate matrix is the artifact a release manager reads.
+//!
+//! ## Run Command
+//! ```bash
+//! cargo run --example analysis_qa_report
+//! ```
+//!
+//! ## Format Variants
+//! ```bash
+//! apr qa model.apr          # APR native
+//! apr qa model.gguf         # GGUF
+//! apr qa model.safetensors  # HF SafeTensors
+//! ```
+//!
+//! ## References
+//! - Sculley, D. et al. (2015). *Hidden Technical Debt in Machine Learning Systems*. NeurIPS. arXiv:1503.05991
+
+use apr_cookbook::prelude::*;
+use apr_cookbook::{CookbookError, Result};
+
+/// The six canonical QA gates.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Gate {
+    Format,
+    Integrity,
+    Performance,
+    Size,
+    Accuracy,
+    Security,
+}
+
+impl Gate {
+    pub fn all() -> [Gate; 6] {
+        [
+            Gate::Format,
+            Gate::Integrity,
+            Gate::Performance,
+            Gate::Size,
+            Gate::Accuracy,
+            Gate::Security,
+        ]
+    }
+
+    pub fn label(self) -> &'static str {
+        match self {
+            Gate::Format => "Format",
+            Gate::Integrity => "Integrity",
+            Gate::Performance => "Performance",
+            Gate::Size => "Size",
+            Gate::Accuracy => "Accuracy",
+            Gate::Security => "Security",
+        }
+    }
+}
+
+/// A single gate outcome for a single model.
+#[derive(Debug, Clone, PartialEq)]
+pub struct GateOutcome {
+    pub gate: Gate,
+    pub passed: bool,
+    pub detail: String,
+}
+
+/// QA outcome for one candidate model.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ModelQa {
+    pub name: String,
+    pub size_bytes: usize,
+    pub outcomes: Vec<GateOutcome>,
+}
+
+impl ModelQa {
+    #[must_use]
+    pub fn overall_pass(&self) -> bool {
+        self.outcomes.iter().all(|o| o.passed)
+    }
+
+    #[must_use]
+    pub fn passed_count(&self) -> usize {
+        self.outcomes.iter().filter(|o| o.passed).count()
+    }
+}
+
+/// Build a deterministic synthetic APR model bundle with the given name.
+fn build_synthetic_model(name: &str, dim: usize) -> Vec<u8> {
+    let seed = hash_name_to_seed(name);
+    let weights = generate_model_payload(seed, dim * dim);
+    let bias = generate_model_payload(seed + 1, dim);
+    ModelBundleV2::new()
+        .with_name(name)
+        .with_compression(Compression::Lz4)
+        .with_quantization(Quantization::FP32)
+        .add_tensor("weight", vec![dim, dim], weights)
+        .add_tensor("bias", vec![dim], bias)
+        .build()
+}
+
+/// Corrupt a clean bundle in a specific way to force a gate to fail.
+fn corrupt_bundle(bundle: &[u8], mode: &str) -> Vec<u8> {
+    let mut bad = bundle.to_vec();
+    match mode {
+        // Break APR2 magic — Format gate fails
+        "format" => bad[0] = b'X',
+        // Inject a URL pattern — Security gate fails
+        "security" => {
+            let url = b"http://evil.com";
+            let off = 100.min(bad.len().saturating_sub(url.len()));
+            if off + url.len() <= bad.len() {
+                bad[off..off + url.len()].copy_from_slice(url);
+            }
+        }
+        // Leave clean
+        _ => {}
+    }
+    bad
+}
+
+/// Run the 6-gate matrix against one model bundle and record outcomes.
+#[must_use]
+pub fn run_qa_matrix(name: &str, bundle: &[u8]) -> ModelQa {
+    let mut outcomes = Vec::new();
+
+    // Gate 1: Format — APR2 magic + minimum length.
+    let format_ok = bundle.len() >= 8 && &bundle[0..4] == b"APR2";
+    outcomes.push(GateOutcome {
+        gate: Gate::Format,
+        passed: format_ok,
+        detail: if format_ok {
+            "APR2 magic ok".into()
+        } else {
+            "magic mismatch".into()
+        },
+    });
+
+    // Gate 2: Integrity — no long runs of zeros (proxy for truncated payload).
+    let max_zero = count_max_zero_run(bundle);
+    let integrity_ok = max_zero < 2048;
+    outcomes.push(GateOutcome {
+        gate: Gate::Integrity,
+        passed: integrity_ok,
+        detail: format!("max zero run = {max_zero}"),
+    });
+
+    // Gate 3: Performance — size-based latency proxy; 64 KiB ≈ 1 ms budget.
+    let est_ms = bundle.len() as f64 / 65536.0;
+    let perf_ok = est_ms <= 10.0;
+    outcomes.push(GateOutcome {
+        gate: Gate::Performance,
+        passed: perf_ok,
+        detail: format!("est {est_ms:.2} ms"),
+    });
+
+    // Gate 4: Size — must be under 10 MiB.
+    let size_ok = bundle.len() < 10 * 1024 * 1024;
+    outcomes.push(GateOutcome {
+        gate: Gate::Size,
+        passed: size_ok,
+        detail: format!("{} bytes", bundle.len()),
+    });
+
+    // Gate 5: Accuracy — synthetic; we accept any non-empty model.
+    let acc_ok = !bundle.is_empty();
+    outcomes.push(GateOutcome {
+        gate: Gate::Accuracy,
+        passed: acc_ok,
+        detail: "synthetic model: n/a".into(),
+    });
+
+    // Gate 6: Security — no embedded URL.
+    let has_url = bundle
+        .windows(7)
+        .any(|w| w.starts_with(b"http://") || w.starts_with(b"https:/"));
+    let sec_ok = !has_url;
+    outcomes.push(GateOutcome {
+        gate: Gate::Security,
+        passed: sec_ok,
+        detail: if sec_ok {
+            "no embedded URLs".into()
+        } else {
+            "URL found in payload".into()
+        },
+    });
+
+    ModelQa {
+        name: name.to_string(),
+        size_bytes: bundle.len(),
+        outcomes,
+    }
+}
+
+fn count_max_zero_run(data: &[u8]) -> usize {
+    let mut best = 0usize;
+    let mut run = 0usize;
+    for b in data {
+        if *b == 0 {
+            run += 1;
+            if run > best {
+                best = run;
+            }
+        } else {
+            run = 0;
+        }
+    }
+    best
+}
+
+/// Render a GFM markdown report: one row per model, one column per gate.
+#[must_use]
+pub fn render_markdown(reports: &[ModelQa]) -> String {
+    let mut s = String::new();
+    s.push_str("# QA Report\n\n");
+    s.push_str(
+        "| Model | Format | Integrity | Performance | Size | Accuracy | Security | Overall |\n",
+    );
+    s.push_str(
+        "|-------|--------|-----------|-------------|------|----------|----------|---------|\n",
+    );
+    for r in reports {
+        s.push_str(&format!("| {} ", r.name));
+        for g in Gate::all() {
+            let cell = r.outcomes.iter().find(|o| o.gate == g).map_or("?", |o| {
+                if o.passed {
+                    "PASS"
+                } else {
+                    "FAIL"
+                }
+            });
+            s.push_str(&format!("| {cell} "));
+        }
+        s.push_str(&format!(
+            "| {} |\n",
+            if r.overall_pass() { "PASS" } else { "FAIL" }
+        ));
+    }
+    s
+}
+
+fn main() -> Result<()> {
+    let mut ctx = RecipeContext::new("analysis_qa_report")?;
+    println!("=== Recipe: {} ===\n", ctx.name());
+
+    // --- Section 1: Build three synthetic candidate models ----------------
+    println!("--- Building 3 synthetic models ---");
+    let clean = build_synthetic_model("model-clean", 32);
+    let bad_format = corrupt_bundle(&clean, "format");
+    let bad_sec = corrupt_bundle(&clean, "security");
+    let bad_sec_named = bad_sec.clone();
+
+    println!("  model-clean       : {} bytes", clean.len());
+    println!(
+        "  model-bad-format  : {} bytes (APR2 magic broken)",
+        bad_format.len()
+    );
+    println!(
+        "  model-bad-security: {} bytes (URL injected)",
+        bad_sec_named.len()
+    );
+
+    // Persist all three to the tempdir so a real `apr qa` invocation could pick them up.
+    for (name, bytes) in [
+        ("model-clean.apr", &clean),
+        ("model-bad-format.apr", &bad_format),
+        ("model-bad-security.apr", &bad_sec_named),
+    ] {
+        let p = ctx.path(name);
+        std::fs::write(&p, bytes)?;
+    }
+    println!();
+
+    // --- Section 2: Run the 6-gate matrix on each ------------------------
+    println!("--- Running QA matrix ---");
+    let reports = vec![
+        run_qa_matrix("model-clean", &clean),
+        run_qa_matrix("model-bad-format", &bad_format),
+        run_qa_matrix("model-bad-security", &bad_sec),
+    ];
+    for r in &reports {
+        println!(
+            "  {:<22} — {}/{} gates pass ({})",
+            r.name,
+            r.passed_count(),
+            r.outcomes.len(),
+            if r.overall_pass() { "PASS" } else { "FAIL" },
+        );
+    }
+    println!();
+
+    // --- Section 3: Render and persist the markdown report ---------------
+    let md = render_markdown(&reports);
+    let md_path = ctx.path("qa_report.md");
+    std::fs::write(&md_path, &md)?;
+    println!("--- Markdown Report ---\n");
+    print!("{md}");
+    println!();
+    println!("Wrote {}", md_path.display());
+    println!();
+
+    // --- Section 4: Aggregate metrics -----------------------------------
+    let total_models = reports.len();
+    let total_gate_cells = reports.iter().map(|r| r.outcomes.len()).sum::<usize>();
+    let passing_cells = reports.iter().map(ModelQa::passed_count).sum::<usize>();
+    let overall_pass = reports.iter().filter(|r| r.overall_pass()).count();
+
+    ctx.record_metric("models_total", total_models as i64);
+    ctx.record_metric("models_pass", overall_pass as i64);
+    ctx.record_metric("gate_cells_total", total_gate_cells as i64);
+    ctx.record_metric("gate_cells_pass", passing_cells as i64);
+    ctx.record_string_metric(
+        "verdict",
+        if overall_pass == total_models {
+            "ALL_PASS"
+        } else {
+            "SOME_FAIL"
+        },
+    );
+
+    // Sanity: the JSON summary is also available for CI dashboards.
+    let summary = serde_json::json!({
+        "schema_version": 1,
+        "sub": "qa",
+        "models": reports.iter().map(|r| serde_json::json!({
+            "name": r.name,
+            "size_bytes": r.size_bytes,
+            "passed": r.passed_count(),
+            "total": r.outcomes.len(),
+            "overall_pass": r.overall_pass(),
+        })).collect::<Vec<_>>(),
+    });
+    let summary_path = ctx.path("qa_report.json");
+    std::fs::write(
+        &summary_path,
+        serde_json::to_vec_pretty(&summary)
+            .map_err(|e| CookbookError::Serialization(e.to_string()))?,
+    )?;
+    println!("Wrote {}", summary_path.display());
+
+    ctx.report()?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_clean_model_passes_all_gates() {
+        let bundle = build_synthetic_model("t-clean", 16);
+        let r = run_qa_matrix("t-clean", &bundle);
+        assert!(
+            r.overall_pass(),
+            "clean model should pass; outcomes={:?}",
+            r.outcomes
+        );
+        assert_eq!(r.outcomes.len(), 6);
+    }
+
+    #[test]
+    fn test_bad_format_fails_format_gate() {
+        let bundle = build_synthetic_model("t-bad-format", 16);
+        let bad = corrupt_bundle(&bundle, "format");
+        let r = run_qa_matrix("t-bad-format", &bad);
+        let fmt = r
+            .outcomes
+            .iter()
+            .find(|o| o.gate == Gate::Format)
+            .expect("must have format gate");
+        assert!(
+            !fmt.passed,
+            "format gate should fail after magic corruption"
+        );
+        assert!(!r.overall_pass());
+    }
+
+    #[test]
+    fn test_bad_security_fails_security_gate() {
+        let bundle = build_synthetic_model("t-bad-sec", 16);
+        let bad = corrupt_bundle(&bundle, "security");
+        let r = run_qa_matrix("t-bad-sec", &bad);
+        let sec = r
+            .outcomes
+            .iter()
+            .find(|o| o.gate == Gate::Security)
+            .expect("must have security gate");
+        assert!(!sec.passed);
+        assert!(!r.overall_pass());
+    }
+
+    #[test]
+    fn test_markdown_has_header_and_rows() {
+        let bundle = build_synthetic_model("t-md", 16);
+        let reports = vec![run_qa_matrix("a", &bundle), run_qa_matrix("b", &bundle)];
+        let md = render_markdown(&reports);
+        assert!(md.contains("| Model |"));
+        assert!(md.contains("| a |"));
+        assert!(md.contains("| b |"));
+        assert!(md.contains("Overall"));
+    }
+
+    #[test]
+    fn test_gate_all_returns_six() {
+        assert_eq!(Gate::all().len(), 6);
+    }
+}

--- a/examples/analysis/analysis_tensors_stats.rs
+++ b/examples/analysis/analysis_tensors_stats.rs
@@ -1,0 +1,408 @@
+//! # Recipe: Per-Tensor Statistics Histogram
+//!
+//! **Category**: analysis
+//! **CLI Equivalent**: `apr tensors model.apr --stats`
+//! **Isolation Level**: Full
+//! **Idempotency**: Guaranteed
+//! **Dependencies**: apr-cookbook (default features)
+//! Contract: contracts/recipe-iiur-v1.yaml
+//!
+//! ## QA Checklist
+//! 1. [x] `cargo run --example analysis_tensors_stats` exits 0
+//! 2. [x] `cargo test --example analysis_tensors_stats` passes
+//! 3. [x] Deterministic output (same seed → same mean/std/sparsity)
+//! 4. [x] No temp files leaked (RecipeContext tempdir)
+//! 5. [x] No `unwrap()` in main logic
+//! 6. [x] Clippy clean under `-D warnings`
+//! 7. [x] NaN count is accurate (explicit injection test)
+//!
+//! ## Learning Objective
+//! Demonstrates per-tensor weight statistics — mean, std, min, max, NaN count,
+//! and sparsity — on a synthetic 10-tensor model with mixed FP32/FP16/INT8
+//! dtypes and varied shapes. Reveals the health-check pattern Glorot & Bengio
+//! first catalogued in 2010: weights drifting toward zero mean with ~1/√n
+//! variance is a signature of a properly initialised feed-forward layer.
+//!
+//! ## Run Command
+//! ```bash
+//! cargo run --example analysis_tensors_stats
+//! ```
+//!
+//! ## Format Variants
+//! ```bash
+//! apr tensors model.apr          --stats  # APR native
+//! apr tensors model.gguf         --stats  # GGUF
+//! apr tensors model.safetensors  --stats  # HF SafeTensors
+//! ```
+//!
+//! ## References
+//! - Glorot, X. & Bengio, Y. (2010). *Understanding the difficulty of training deep feedforward neural networks*. AISTATS. URL: proceedings.mlr.press/v9/glorot10a.html
+
+use apr_cookbook::prelude::*;
+use apr_cookbook::{CookbookError, Result};
+use rand::Rng;
+
+/// Tensor element dtype.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DType {
+    FP32,
+    FP16,
+    INT8,
+}
+
+impl DType {
+    pub fn label(self) -> &'static str {
+        match self {
+            DType::FP32 => "fp32",
+            DType::FP16 => "fp16",
+            DType::INT8 => "int8",
+        }
+    }
+
+    pub fn element_bytes(self) -> usize {
+        match self {
+            DType::FP32 => 4,
+            DType::FP16 => 2,
+            DType::INT8 => 1,
+        }
+    }
+}
+
+/// Descriptor for one synthetic tensor.
+#[derive(Debug, Clone)]
+pub struct SyntheticTensor {
+    pub name: String,
+    pub shape: Vec<usize>,
+    pub dtype: DType,
+    pub values: Vec<f32>,
+}
+
+impl SyntheticTensor {
+    #[must_use]
+    pub fn numel(&self) -> usize {
+        self.shape.iter().product()
+    }
+
+    #[must_use]
+    pub fn size_bytes(&self) -> usize {
+        self.numel() * self.dtype.element_bytes()
+    }
+}
+
+/// Computed statistics for a single tensor.
+#[derive(Debug, Clone, PartialEq)]
+pub struct TensorStats {
+    pub mean: f32,
+    pub std: f32,
+    pub min: f32,
+    pub max: f32,
+    pub nan_count: usize,
+    pub sparsity_pct: f32,
+}
+
+/// Compute per-tensor statistics, ignoring NaN for mean/std/min/max and
+/// reporting sparsity as the fraction of exactly-zero elements.
+#[must_use]
+pub fn compute_stats(values: &[f32]) -> TensorStats {
+    if values.is_empty() {
+        return TensorStats {
+            mean: 0.0,
+            std: 0.0,
+            min: 0.0,
+            max: 0.0,
+            nan_count: 0,
+            sparsity_pct: 100.0,
+        };
+    }
+
+    let nan_count = values.iter().filter(|v| v.is_nan()).count();
+    let finite: Vec<f32> = values.iter().copied().filter(|v| v.is_finite()).collect();
+
+    if finite.is_empty() {
+        return TensorStats {
+            mean: 0.0,
+            std: 0.0,
+            min: 0.0,
+            max: 0.0,
+            nan_count,
+            sparsity_pct: 0.0,
+        };
+    }
+
+    let n = finite.len() as f32;
+    let mean = finite.iter().sum::<f32>() / n;
+    let var = finite.iter().map(|v| (*v - mean).powi(2)).sum::<f32>() / n;
+    let std = var.sqrt();
+    let min = finite.iter().copied().fold(f32::INFINITY, f32::min);
+    let max = finite.iter().copied().fold(f32::NEG_INFINITY, f32::max);
+    let zeros = values.iter().filter(|v| **v == 0.0).count();
+    let sparsity_pct = 100.0 * zeros as f32 / values.len() as f32;
+
+    TensorStats {
+        mean,
+        std,
+        min,
+        max,
+        nan_count,
+        sparsity_pct,
+    }
+}
+
+/// Build 10 synthetic tensors with varied dtypes and shapes.
+pub fn build_tensors(rng: &mut impl Rng) -> Vec<SyntheticTensor> {
+    fn gaussian(rng: &mut impl Rng, shape: &[usize], scale: f32) -> Vec<f32> {
+        let n: usize = shape.iter().product();
+        (0..n)
+            .map(|_| (rng.gen::<f32>() - 0.5) * 2.0 * scale)
+            .collect()
+    }
+
+    let mut ts = Vec::with_capacity(10);
+    ts.push(SyntheticTensor {
+        name: "embed_tokens.weight".into(),
+        values: gaussian(rng, &[64, 16], 0.02),
+        shape: vec![64, 16],
+        dtype: DType::FP16,
+    });
+    ts.push(SyntheticTensor {
+        name: "layers.0.attn.q_proj.weight".into(),
+        values: gaussian(rng, &[16, 16], 0.1),
+        shape: vec![16, 16],
+        dtype: DType::FP32,
+    });
+    ts.push(SyntheticTensor {
+        name: "layers.0.attn.k_proj.weight".into(),
+        values: gaussian(rng, &[16, 16], 0.1),
+        shape: vec![16, 16],
+        dtype: DType::FP32,
+    });
+    ts.push(SyntheticTensor {
+        name: "layers.0.attn.v_proj.weight".into(),
+        values: gaussian(rng, &[16, 16], 0.1),
+        shape: vec![16, 16],
+        dtype: DType::FP32,
+    });
+    ts.push(SyntheticTensor {
+        name: "layers.0.mlp.gate_proj.weight".into(),
+        values: gaussian(rng, &[32, 16], 0.05),
+        shape: vec![32, 16],
+        dtype: DType::FP32,
+    });
+    // Deliberately sparse tensor — demonstrates the sparsity column.
+    let mut sparse = gaussian(rng, &[32, 16], 0.05);
+    for (i, v) in sparse.iter_mut().enumerate() {
+        if i % 3 == 0 {
+            *v = 0.0;
+        }
+    }
+    ts.push(SyntheticTensor {
+        name: "layers.0.mlp.up_proj.weight".into(),
+        values: sparse,
+        shape: vec![32, 16],
+        dtype: DType::FP32,
+    });
+    ts.push(SyntheticTensor {
+        name: "layers.0.mlp.down_proj.weight".into(),
+        values: gaussian(rng, &[16, 32], 0.05),
+        shape: vec![16, 32],
+        dtype: DType::INT8,
+    });
+    ts.push(SyntheticTensor {
+        name: "layers.0.norm.weight".into(),
+        values: vec![1.0; 16],
+        shape: vec![16],
+        dtype: DType::FP32,
+    });
+    ts.push(SyntheticTensor {
+        name: "lm_head.weight".into(),
+        values: gaussian(rng, &[64, 16], 0.02),
+        shape: vec![64, 16],
+        dtype: DType::INT8,
+    });
+    ts.push(SyntheticTensor {
+        name: "output_norm.weight".into(),
+        values: gaussian(rng, &[16], 0.01),
+        shape: vec![16],
+        dtype: DType::FP32,
+    });
+    ts
+}
+
+/// Render an aligned plain-text table with per-tensor stats.
+#[must_use]
+pub fn render_table(tensors: &[SyntheticTensor], stats: &[TensorStats]) -> String {
+    let mut s = String::new();
+    s.push_str(&format!(
+        "  {:<32} {:<10} {:<5}   {:>8}   {:>8}   {:>8}   {:>8}   {:>4}   {:>6}\n",
+        "name", "shape", "dtype", "mean", "std", "min", "max", "nan", "spars%"
+    ));
+    s.push_str(&format!("  {}\n", "-".repeat(112)));
+    for (t, st) in tensors.iter().zip(stats.iter()) {
+        let shape_str = format!("{:?}", t.shape);
+        s.push_str(&format!(
+            "  {:<32} {:<10} {:<5}   {:>8.4}   {:>8.4}   {:>8.4}   {:>8.4}   {:>4}   {:>5.1}%\n",
+            t.name,
+            shape_str,
+            t.dtype.label(),
+            st.mean,
+            st.std,
+            st.min,
+            st.max,
+            st.nan_count,
+            st.sparsity_pct,
+        ));
+    }
+    s
+}
+
+fn main() -> Result<()> {
+    let mut ctx = RecipeContext::new("analysis_tensors_stats")?;
+    println!("=== Recipe: {} ===\n", ctx.name());
+
+    // --- Section 1: Build 10 synthetic tensors ---------------------------
+    let tensors = build_tensors(ctx.rng());
+    println!(
+        "Built {} synthetic tensors across 3 dtypes.\n",
+        tensors.len()
+    );
+
+    // --- Section 2: Compute per-tensor statistics ------------------------
+    let stats: Vec<TensorStats> = tensors.iter().map(|t| compute_stats(&t.values)).collect();
+
+    // --- Section 3: Render aligned table --------------------------------
+    println!("--- Per-Tensor Statistics (apr tensors --stats) ---\n");
+    let table = render_table(&tensors, &stats);
+    print!("{table}");
+    println!();
+
+    // --- Section 4: Dtype breakdown -------------------------------------
+    let (mut fp32_bytes, mut fp16_bytes, mut int8_bytes) = (0usize, 0usize, 0usize);
+    for t in &tensors {
+        match t.dtype {
+            DType::FP32 => fp32_bytes += t.size_bytes(),
+            DType::FP16 => fp16_bytes += t.size_bytes(),
+            DType::INT8 => int8_bytes += t.size_bytes(),
+        }
+    }
+    println!("--- Dtype Breakdown ---");
+    println!("  fp32: {} bytes", fp32_bytes);
+    println!("  fp16: {} bytes", fp16_bytes);
+    println!("  int8: {} bytes", int8_bytes);
+    println!();
+
+    // --- Section 5: Persist JSON summary --------------------------------
+    let summary = serde_json::json!({
+        "schema_version": 1,
+        "sub": "tensors",
+        "tensors": tensors.iter().zip(stats.iter()).map(|(t, st)| serde_json::json!({
+            "name": t.name,
+            "shape": t.shape,
+            "dtype": t.dtype.label(),
+            "mean": st.mean,
+            "std": st.std,
+            "min": st.min,
+            "max": st.max,
+            "nan_count": st.nan_count,
+            "sparsity_pct": st.sparsity_pct,
+        })).collect::<Vec<_>>(),
+    });
+    let summary_path = ctx.path("tensors_stats.json");
+    std::fs::write(
+        &summary_path,
+        serde_json::to_vec_pretty(&summary)
+            .map_err(|e| CookbookError::Serialization(e.to_string()))?,
+    )?;
+    println!("Wrote {}", summary_path.display());
+
+    // --- Section 6: Metrics --------------------------------------------
+    let total_nans: usize = stats.iter().map(|s| s.nan_count).sum();
+    let avg_sparsity: f32 = stats.iter().map(|s| s.sparsity_pct).sum::<f32>() / stats.len() as f32;
+    ctx.record_metric("tensors_total", tensors.len() as i64);
+    ctx.record_metric("nan_total", total_nans as i64);
+    ctx.record_float_metric("sparsity_avg_pct", f64::from(avg_sparsity));
+
+    ctx.report()?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rand::SeedableRng;
+
+    fn test_rng() -> rand::rngs::StdRng {
+        rand::rngs::StdRng::seed_from_u64(42)
+    }
+
+    #[test]
+    fn test_build_ten_tensors() {
+        let mut rng = test_rng();
+        let ts = build_tensors(&mut rng);
+        assert_eq!(ts.len(), 10);
+    }
+
+    #[test]
+    fn test_dtype_element_bytes() {
+        assert_eq!(DType::FP32.element_bytes(), 4);
+        assert_eq!(DType::FP16.element_bytes(), 2);
+        assert_eq!(DType::INT8.element_bytes(), 1);
+    }
+
+    #[test]
+    fn test_compute_stats_mean_std_min_max() {
+        let data = vec![1.0, 2.0, 3.0, 4.0, 5.0];
+        let st = compute_stats(&data);
+        assert!((st.mean - 3.0).abs() < 1e-5);
+        assert!((st.min - 1.0).abs() < 1e-5);
+        assert!((st.max - 5.0).abs() < 1e-5);
+        assert_eq!(st.nan_count, 0);
+    }
+
+    #[test]
+    fn test_compute_stats_counts_nans() {
+        let data = vec![1.0, f32::NAN, 3.0, f32::NAN, f32::NAN];
+        let st = compute_stats(&data);
+        assert_eq!(st.nan_count, 3);
+    }
+
+    #[test]
+    fn test_compute_stats_sparsity() {
+        let data = vec![0.0, 0.0, 0.0, 1.0];
+        let st = compute_stats(&data);
+        assert!((st.sparsity_pct - 75.0).abs() < 1e-5);
+    }
+
+    #[test]
+    fn test_compute_stats_empty() {
+        let st = compute_stats(&[]);
+        assert_eq!(st.nan_count, 0);
+        assert!((st.sparsity_pct - 100.0).abs() < 1e-5);
+    }
+
+    #[test]
+    fn test_table_includes_header_and_each_tensor() {
+        let mut rng = test_rng();
+        let ts = build_tensors(&mut rng);
+        let sts: Vec<_> = ts.iter().map(|t| compute_stats(&t.values)).collect();
+        let table = render_table(&ts, &sts);
+        assert!(table.contains("name"));
+        for t in &ts {
+            assert!(table.contains(&t.name), "table missing tensor {}", t.name);
+        }
+    }
+
+    #[test]
+    fn test_deterministic_with_same_seed() {
+        let ts1 = build_tensors(&mut test_rng());
+        let ts2 = build_tensors(&mut test_rng());
+        assert_eq!(ts1.len(), ts2.len());
+        for (a, b) in ts1.iter().zip(ts2.iter()) {
+            assert_eq!(a.name, b.name);
+            assert_eq!(a.shape, b.shape);
+            assert_eq!(a.values.len(), b.values.len());
+            for (va, vb) in a.values.iter().zip(b.values.iter()) {
+                assert!((va - vb).abs() < 1e-6);
+            }
+        }
+    }
+}

--- a/examples/inference/inference_run_temperature_sweep.rs
+++ b/examples/inference/inference_run_temperature_sweep.rs
@@ -1,0 +1,357 @@
+//! # Recipe: Decode Temperature Sweep
+//!
+//! **Category**: inference
+//! **CLI Equivalent**: `apr run model.apr --prompt "..." --temperature <T>`
+//! **Isolation Level**: Full
+//! **Idempotency**: Guaranteed
+//! **Dependencies**: apr-cookbook (default features)
+//! Contract: contracts/recipe-iiur-v1.yaml
+//!
+//! ## QA Checklist
+//! 1. [x] `cargo run --example inference_run_temperature_sweep` exits 0
+//! 2. [x] `cargo test --example inference_run_temperature_sweep` passes
+//! 3. [x] Deterministic output (same seed → same sequences)
+//! 4. [x] No temp files leaked (RecipeContext tempdir)
+//! 5. [x] No `unwrap()` in main logic
+//! 6. [x] Clippy clean under `-D warnings`
+//! 7. [x] T=0.0 is pure argmax (always picks top token)
+//! 8. [x] Entropy is monotone non-decreasing in T across the sweep
+//!
+//! ## Learning Objective
+//! Demonstrates the *decode temperature sweep* pattern behind `apr run`.
+//! Starting from a fixed 8-token logit distribution, we softmax-sample at
+//! T ∈ {0.0, 0.3, 0.7, 1.0, 1.5} and trace the output shift from deterministic
+//! argmax (T=0.0) to high-entropy divergence (T=1.5). Reveals the trade-off
+//! Holtzman et al. catalogue as "neural text degeneration" — too low and you
+//! get repetition; too high and you get nonsense.
+//!
+//! ## Run Command
+//! ```bash
+//! cargo run --example inference_run_temperature_sweep
+//! ```
+//!
+//! ## Format Variants
+//! ```bash
+//! apr run model.apr          --temperature 0.7  # APR native
+//! apr run model.gguf         --temperature 0.7  # GGUF
+//! apr run model.safetensors  --temperature 0.7  # HF SafeTensors
+//! ```
+//!
+//! ## References
+//! - Holtzman, A. et al. (2020). *The Curious Case of Neural Text Degeneration*. ICLR. arXiv:1904.09751
+
+use apr_cookbook::prelude::*;
+use apr_cookbook::{CookbookError, Result};
+use rand::Rng;
+
+/// A deterministic 8-slot logit distribution ordered high → low.
+/// Token index 0 is the argmax; index 7 is the tail.
+#[must_use]
+pub fn canonical_logits() -> Vec<f32> {
+    vec![4.0, 3.6, 3.0, 2.4, 1.8, 1.0, 0.2, -0.5]
+}
+
+/// Temperature-scaled softmax. T=0.0 returns a one-hot on argmax.
+#[must_use]
+pub fn softmax_temperature(logits: &[f32], temperature: f32) -> Vec<f32> {
+    if temperature <= 0.0 {
+        // Pure argmax — one-hot.
+        let argmax = argmax_index(logits);
+        let mut out = vec![0.0; logits.len()];
+        if argmax < out.len() {
+            out[argmax] = 1.0;
+        }
+        return out;
+    }
+    let max = logits.iter().copied().fold(f32::NEG_INFINITY, f32::max);
+    let exps: Vec<f32> = logits
+        .iter()
+        .map(|&v| ((v - max) / temperature).exp())
+        .collect();
+    let sum: f32 = exps.iter().sum();
+    if sum == 0.0 {
+        return vec![0.0; logits.len()];
+    }
+    exps.into_iter().map(|e| e / sum).collect()
+}
+
+#[must_use]
+pub fn argmax_index(logits: &[f32]) -> usize {
+    let mut best = 0usize;
+    let mut best_v = f32::NEG_INFINITY;
+    for (i, v) in logits.iter().enumerate() {
+        if *v > best_v {
+            best_v = *v;
+            best = i;
+        }
+    }
+    best
+}
+
+/// Sample a token index from a probability distribution using `rng`.
+///
+/// For T=0.0 the distribution is already one-hot, so we fall through to
+/// argmax without consuming RNG state.
+pub fn sample_token(probs: &[f32], rng: &mut impl Rng) -> usize {
+    if probs.iter().filter(|p| **p > 0.0).count() <= 1 {
+        return argmax_index(probs);
+    }
+    let r: f32 = rng.gen();
+    let mut acc = 0.0_f32;
+    for (i, p) in probs.iter().enumerate() {
+        acc += *p;
+        if r <= acc {
+            return i;
+        }
+    }
+    probs.len() - 1
+}
+
+/// Shannon entropy (nats).
+#[must_use]
+pub fn entropy(probs: &[f32]) -> f32 {
+    let mut h = 0.0_f32;
+    for &p in probs {
+        if p > 0.0 {
+            h -= p * p.ln();
+        }
+    }
+    h
+}
+
+/// Sweep outcome at a single temperature.
+#[derive(Debug, Clone, PartialEq)]
+pub struct SweepRow {
+    pub temperature: f32,
+    pub entropy: f32,
+    pub sampled_tokens: Vec<usize>,
+    pub unique_count: usize,
+}
+
+/// Sample `k` tokens from the logit distribution at temperature `t`.
+pub fn sweep_at(logits: &[f32], temperature: f32, samples: usize, rng: &mut impl Rng) -> SweepRow {
+    let probs = softmax_temperature(logits, temperature);
+    let mut tokens = Vec::with_capacity(samples);
+    for _ in 0..samples {
+        tokens.push(sample_token(&probs, rng));
+    }
+    let unique: std::collections::HashSet<_> = tokens.iter().copied().collect();
+    SweepRow {
+        temperature,
+        entropy: entropy(&probs),
+        sampled_tokens: tokens,
+        unique_count: unique.len(),
+    }
+}
+
+/// Render the sweep as an aligned table.
+#[must_use]
+pub fn render_sweep(rows: &[SweepRow]) -> String {
+    let mut s = String::new();
+    s.push_str(&format!(
+        "  {:<6} {:>8} {:>8} {:>10}   {}\n",
+        "T", "entropy", "unique", "samples", "preview"
+    ));
+    s.push_str(&format!("  {}\n", "-".repeat(80)));
+    for r in rows {
+        let preview: Vec<String> = r
+            .sampled_tokens
+            .iter()
+            .take(12)
+            .map(|i| format!("t{i}"))
+            .collect();
+        s.push_str(&format!(
+            "  {:<6.2} {:>8.4} {:>8} {:>10}   {}\n",
+            r.temperature,
+            r.entropy,
+            r.unique_count,
+            r.sampled_tokens.len(),
+            preview.join(" "),
+        ));
+    }
+    s
+}
+
+fn main() -> Result<()> {
+    let mut ctx = RecipeContext::new("inference_run_temperature_sweep")?;
+    println!("=== Recipe: {} ===\n", ctx.name());
+
+    // --- Section 1: Fixed logit distribution -----------------------------
+    let logits = canonical_logits();
+    println!("--- Canonical Logits ---");
+    for (i, v) in logits.iter().enumerate() {
+        println!("  t{i:<2}  logit = {v:>6.2}");
+    }
+    println!();
+
+    // --- Section 2: Sweep across 5 temperatures ------------------------
+    let temperatures = [0.0_f32, 0.3, 0.7, 1.0, 1.5];
+    let samples_per_temp = 30;
+    let mut rows = Vec::with_capacity(temperatures.len());
+    for &t in &temperatures {
+        rows.push(sweep_at(&logits, t, samples_per_temp, ctx.rng()));
+    }
+
+    // --- Section 3: Render the sweep table -----------------------------
+    println!(
+        "--- Temperature Sweep ({} samples per T) ---\n",
+        samples_per_temp
+    );
+    print!("{}", render_sweep(&rows));
+    println!();
+
+    // --- Section 4: Assertion — T=0.0 produces pure argmax ------------
+    if let Some(cold) = rows.first() {
+        let unique = cold.unique_count;
+        if unique != 1 {
+            return Err(CookbookError::invalid_format(format!(
+                "T=0.0 must be deterministic (unique=1), got unique={unique}"
+            )));
+        }
+        println!("✓ T=0.0 collapses to argmax (unique token count = 1)");
+    }
+
+    // --- Section 5: Assertion — entropy is non-decreasing in T ---------
+    let mut prev = f32::NEG_INFINITY;
+    for r in &rows {
+        if r.entropy + 1e-5 < prev {
+            return Err(CookbookError::invalid_format(format!(
+                "entropy not monotone at T={}: {} < prev {}",
+                r.temperature, r.entropy, prev
+            )));
+        }
+        prev = r.entropy;
+    }
+    println!("✓ Entropy is monotone non-decreasing across the sweep\n");
+
+    // --- Section 6: Persist sweep JSON --------------------------------
+    let summary = serde_json::json!({
+        "schema_version": 1,
+        "sub": "run",
+        "logits": logits,
+        "rows": rows.iter().map(|r| serde_json::json!({
+            "temperature": r.temperature,
+            "entropy": r.entropy,
+            "unique": r.unique_count,
+            "samples": r.sampled_tokens,
+        })).collect::<Vec<_>>(),
+    });
+    let path = ctx.path("temperature_sweep.json");
+    std::fs::write(
+        &path,
+        serde_json::to_vec_pretty(&summary)
+            .map_err(|e| CookbookError::Serialization(e.to_string()))?,
+    )?;
+    println!("Wrote {}", path.display());
+
+    // --- Section 7: Metrics ------------------------------------------
+    let highest_entropy = rows.last().map_or(0.0, |r| r.entropy);
+    let largest_unique = rows.iter().map(|r| r.unique_count).max().unwrap_or(0);
+    ctx.record_float_metric("entropy_at_Tmax", f64::from(highest_entropy));
+    ctx.record_metric("max_unique_tokens", largest_unique as i64);
+    ctx.record_string_metric("verdict", "SWEEP_OK");
+
+    ctx.report()?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rand::SeedableRng;
+
+    fn test_rng() -> rand::rngs::StdRng {
+        rand::rngs::StdRng::seed_from_u64(42)
+    }
+
+    #[test]
+    fn test_softmax_temperature_sum_to_one() {
+        let probs = softmax_temperature(&canonical_logits(), 1.0);
+        let sum: f32 = probs.iter().sum();
+        assert!((sum - 1.0).abs() < 1e-5, "sum = {sum}");
+    }
+
+    #[test]
+    fn test_softmax_zero_temperature_is_onehot() {
+        let probs = softmax_temperature(&canonical_logits(), 0.0);
+        let sum: f32 = probs.iter().sum();
+        assert!((sum - 1.0).abs() < 1e-5);
+        assert!((probs[0] - 1.0).abs() < 1e-5, "argmax must be 1.0");
+        for &p in probs.iter().skip(1) {
+            assert!(p.abs() < 1e-6, "non-argmax must be 0");
+        }
+    }
+
+    #[test]
+    fn test_argmax_index_picks_first_max() {
+        assert_eq!(argmax_index(&[0.0, 3.0, 1.0, 2.9]), 1);
+    }
+
+    #[test]
+    fn test_entropy_uniform_is_ln_n() {
+        let n = 4;
+        let p = vec![1.0 / n as f32; n];
+        let h = entropy(&p);
+        let expected = (n as f32).ln();
+        assert!((h - expected).abs() < 1e-5, "H={h}, expected={expected}");
+    }
+
+    #[test]
+    fn test_entropy_one_hot_is_zero() {
+        let p = vec![1.0_f32, 0.0, 0.0];
+        let h = entropy(&p);
+        assert!(h.abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_sweep_at_zero_is_deterministic() {
+        let logits = canonical_logits();
+        let mut rng = test_rng();
+        let row = sweep_at(&logits, 0.0, 20, &mut rng);
+        assert_eq!(row.unique_count, 1, "T=0.0 must be deterministic");
+        assert!(row.sampled_tokens.iter().all(|&t| t == 0));
+    }
+
+    #[test]
+    fn test_sweep_entropy_non_decreasing() {
+        let logits = canonical_logits();
+        let mut rng = test_rng();
+        let ts = [0.0_f32, 0.3, 0.7, 1.0, 1.5];
+        let rows: Vec<_> = ts
+            .iter()
+            .map(|&t| sweep_at(&logits, t, 20, &mut rng))
+            .collect();
+        let mut prev = f32::NEG_INFINITY;
+        for r in &rows {
+            assert!(
+                r.entropy + 1e-5 >= prev,
+                "entropy not monotone at T={}: {} < {}",
+                r.temperature,
+                r.entropy,
+                prev
+            );
+            prev = r.entropy;
+        }
+    }
+
+    #[test]
+    fn test_render_sweep_contains_all_temperatures() {
+        let rows = vec![
+            SweepRow {
+                temperature: 0.0,
+                entropy: 0.0,
+                sampled_tokens: vec![0; 5],
+                unique_count: 1,
+            },
+            SweepRow {
+                temperature: 1.5,
+                entropy: 2.0,
+                sampled_tokens: vec![0, 1, 2, 3, 4],
+                unique_count: 5,
+            },
+        ];
+        let table = render_sweep(&rows);
+        assert!(table.contains("0.00"));
+        assert!(table.contains("1.50"));
+    }
+}


### PR DESCRIPTION
## Summary

Final variant-depth sprint for the 4 subcommands previously at exactly 2 recipes. Each gets one new recipe; all 4 now satisfy Invariant F (≥3).

| Sub | New recipe | Variant |
|-----|-----------|---------|
| `compare-hf` | `analysis_compare_hf_threshold.rs` | τ sweep ∈ {1e-3..1e-6}, monotone mismatch count |
| `qa` | `analysis_qa_report.rs` | 6-gate matrix × 3 synthetic models, GFM + JSON |
| `tensors` | `analysis_tensors_stats.rs` | Per-tensor mean/std/min/max/NaN/sparsity × 10 tensors |
| `run` | `inference_run_temperature_sweep.rs` | Softmax sampling T ∈ {0..1.5} |

## Verification

```
cargo build --examples            -> PASS
cargo test (new 4)                -> 26/26 tests
make variant-depth                -> 22/66 (33%)  [was 18/66 (27%)]
cargo clippy -D warnings          -> rc 0
cargo fmt --all -- --check        -> rc 0
```

## Not done

Invariant F still TARGET. Remaining backlog: PMAT-050 (~80 recipes for ~40 subs at 1 recipe). Landing PMAT-050 lifts to 62/66 and enables TARGET → ENFORCED.

(Refs PMAT-051)

🤖 Generated with [Claude Code](https://claude.com/claude-code)