### PR TITLE
chore(hygiene): gitignore workspace.db + deep-context.md; PMAT-062 complete

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,11 @@ examples/advanced/rag_pipeline.proptest-regressions
 .pmat/context.db
 .pmat/context.db-shm
 .pmat/context.db-wal
+.pmat/workspace.db
+.pmat/workspace.db-shm
+.pmat/workspace.db-wal
+# Generated project context snapshot (pmat context --output deep-context.md)
+deep-context.md
 # Per-commit session metadata written by `pmat work start` (PMAT-062)
 .pmat-metrics/commit-*.json
 # pv (aprender-contracts-cli) local lint cache

--- a/docs/roadmaps/roadmap.yaml
+++ b/docs/roadmaps/roadmap.yaml
@@ -1254,7 +1254,7 @@ roadmap:
   github_issue: null
   item_type: task
   title: 'Gitignore hygiene: exclude .pmat-metrics/commit-*.json + .pmat/context.db* transient SQLite files; mark PMAT-061 complete'
-  status: inprogress
+  status: completed
   priority: low
   assigned_to: null
   created: 2026-04-23T10:16:05Z


### PR DESCRIPTION
Follow-up to #240 — two more session-local files still showed in `git status`. Now clean. Marks PMAT-062 completed.