### PR TITLE
fix(ci): PMAT-063 — move unified gate to separate workflow so CI badge is green

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,24 +58,10 @@ jobs:
           cargo audit
         continue-on-error: true
 
-  # The `unified` gate runs on paiml's self-hosted `clean-room` runners and
-  # invokes a Makefile in the private `paiml/infra` repo. When that infra is
-  # in a clean state it layers fmt/clippy/deny/sccache on top of the local
-  # Quality Gate above. When it's not (e.g. a missing binary on the runner
-  # returns 127 at `_provision`), it was historically blocking merges.
-  #
-  # Policy: the `Quality Gate` job above is the source of truth for
-  # correctness — it's reproducible on any `ubuntu-latest` runner and
-  # mirrors `cargo clippy` + `cargo test --all-features` exactly. The
-  # unified gate adds signal but must not block when its own infrastructure
-  # regresses. Until the infra repo's `_provision` target is fixed, this
-  # remains advisory.
-  unified:
-    uses: paiml/.github/.github/workflows/unified-gate.yml@b6c24635217fe302ca1a67352b7de540fb3e02e7
-    with:
-      repo: ${{ github.event.repository.name }}
-      pr_sha: ${{ github.event.pull_request.head.sha || github.sha }}
-    secrets: inherit
+  # Note: the self-hosted `unified` gate lives in its own workflow file
+  # (`unified-gate-advisory.yml`) so its conclusion doesn't taint this
+  # workflow's badge. It is advisory — the required branch-protection
+  # check is `CI Status` (below).
 
   # Lean gate — builds the ProvableContracts Lake project under `lean/`.
   # Catches regressions in the PMAT-047 theorem scaffold (e.g. a theorem

--- a/.github/workflows/unified-gate-advisory.yml
+++ b/.github/workflows/unified-gate-advisory.yml
@@ -1,0 +1,42 @@
+# Unified Gate (advisory) — self-hosted clean-room gate.
+#
+# This workflow calls `paiml/.github@<sha>/unified-gate.yml` which runs on
+# self-hosted `intel-clean-room-*` runners and invokes a Makefile target
+# in the private `paiml/infra` repo. When that infra is healthy it layers
+# fmt/clippy/deny/sccache on top of the local `Quality Gate` job in
+# `ci.yml`.
+#
+# Why a separate workflow file:
+# - GitHub Actions doesn't allow `continue-on-error: true` on a reusable-
+#   workflow `uses:` job at the caller level (only workflow-level inputs
+#   listed in the docs are supported).
+# - If this job lived in `ci.yml`, its failure would make the `CI`
+#   workflow badge red even when `Quality Gate` + `Lean Gate` + `CI Status`
+#   are all green. The self-hosted infra is outside this repo's control
+#   and its brokenness shouldn't drag down the cookbook's own CI signal.
+# - Branch protection requires the `CI Status` check from `ci.yml`, not
+#   anything here. So this workflow is purely informational.
+#
+# When the `paiml/infra` `_provision` target is fixed, this workflow goes
+# green automatically — no change needed here.
+
+name: Unified Gate (advisory)
+
+on:
+  pull_request_target:
+    branches: [main, master]
+  push:
+    branches: [main, master]
+  workflow_dispatch:
+
+concurrency:
+  group: unified-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  unified:
+    uses: paiml/.github/.github/workflows/unified-gate.yml@b6c24635217fe302ca1a67352b7de540fb3e02e7
+    with:
+      repo: ${{ github.event.repository.name }}
+      pr_sha: ${{ github.event.pull_request.head.sha || github.sha }}
+    secrets: inherit


### PR DESCRIPTION
## Why
The self-hosted \`unified\` gate fails because of a broken \`paiml/infra\` \`_provision\` target. Its failure was making the \`CI\` workflow badge red on every run even though \`Quality Gate\` + \`Lean Gate\` + \`CI Status\` were all green. Branch protection requires \`CI Status\` so merges still worked, but the red badge was cosmetically misleading.

\`continue-on-error: true\` can't be applied to reusable-workflow \`uses:\` jobs — GitHub Actions only accepts the keywords in the documented list.

## Fix
Extract the \`unified\` job into its own workflow file \`unified-gate-advisory.yml\`. Same reusable-workflow call, same signal, but its conclusion lives in a separate workflow with its own badge clearly labelled "Unified Gate (advisory)".

\`CI\` workflow now contains only:
- \`gate\` (Quality Gate — reproducible ubuntu-latest)
- \`lean-gate\` (Lean Gate — PMAT-047 scaffold)
- \`ci-status\` (summary, required by branch protection)

## Test plan
- [x] YAML syntax valid for both files
- [ ] Post-merge: \`CI\` workflow badge shows ✅ on main (witness)
- [ ] \`Unified Gate (advisory)\` workflow still runs and surfaces its own red badge until \`paiml/infra\` is fixed

(Refs PMAT-063)

🤖 Generated with [Claude Code](https://claude.com/claude-code)