### PR TITLE
docs(expand-cookbooks): new spec for closing aprender-0.31.x coverage gap

### DIFF
--- a/docs/specifications/expand-cookbooks.md
+++ b/docs/specifications/expand-cookbooks.md
@@ -1,0 +1,85 @@
+# Expand Cookbooks Specification
+
+**Version**: 1.0.0
+**Status**: PROPOSED
+**MSRV**: 1.89 (inherits from apr-cookbook v6.0)
+**Date**: 2026-05-05
+**Repository**: [github.com/paiml/apr-cookbook](https://github.com/paiml/apr-cookbook)
+**Sovereign Stack**: APR-MONO v0.31.2 + sister crates
+
+---
+
+## Executive Summary
+
+apr-cookbook v6.0.0 (centralize-cookbooks) consolidated three predecessor cookbooks. Since then, **aprender 0.31.0..0.31.2 (Unreleased)** shipped substantial new capability — a Claude Messages API drop-in (`apr serve anthropic`), a 21-row Claude Code parity surface (`apr code`), GPU/CPU output-parity oracle bisection (`apr trace --save-tensor` + `apr diff --values` on APRT stage tensors), MCP M5 transports (SSE, WebSocket, notifications), end-to-end publish manifests, plus **6 new sister crates** published at 0.31.2 (`aprender-mcp`, `aprender-tsp`, `aprender-shell`, `aprender-monte-carlo`, `aprender-cgp`, `aprender-contracts-macros`).
+
+The cookbook has **zero recipes** for any of those surfaces. A user landing on the cookbook today learns nothing about: how to bisect a silent-GPU-gibberish bug; how to embed an MCP server in a Rust app; how to use the new code-agent surface; how to publish a model end-to-end; or that the sister crates exist at all.
+
+This spec proposes ~50 new recipes across 6 new categories and 6 existing categories, plus the per-subcrate ≥3-recipe requirement (18 recipes alone). Net: apr-cookbook grows from 28 categories → 34 categories, ~388 recipes → ~440 recipes.
+
+---
+
+## Component Documents
+
+| Document | Purpose |
+|----------|---------|
+| [scope.md](expand-cookbooks/scope.md) | Charter expansion, naming decisions, non-goals |
+| [gap-inventory.md](expand-cookbooks/gap-inventory.md) | Per-capability gap, ranked by user-facing impact |
+| [recipe-catalog.md](expand-cookbooks/recipe-catalog.md) | All planned recipes with names, paths, contracts, citations |
+| [subcrate-coverage.md](expand-cookbooks/subcrate-coverage.md) | ≥3-recipe coverage per sister crate (the hard requirement) |
+| [tickets.md](expand-cookbooks/tickets.md) | PMAT ticket breakdown (PMAT-072..083) |
+
+---
+
+## Acceptance Criteria
+
+The expand-cookbooks initiative is **done** when, and only when:
+
+1. **Recipe count**: every Tier-1/2/3/4 capability listed in [gap-inventory.md](expand-cookbooks/gap-inventory.md) has at least one recipe; every sister crate listed in [subcrate-coverage.md](expand-cookbooks/subcrate-coverage.md) has **≥3** recipes.
+2. **IIUR grade**: every new recipe satisfies `contracts/recipe-iiur-v1.yaml` (Rust binaries) or `contracts/recipe-iiur-config-v1.yaml` (declarative wrappers).
+3. **CLI parity (Invariant A) extended**: every new `apr` subcommand (`apr code`, `apr trace --save-tensor`, `apr serve anthropic`, `apr serve plan` with HF, `apr publish` end-to-end, `apr diff --values` APRT) is covered by at least one recipe.
+4. **Cargo.toml**: new sister-crate dev-dependencies declared (`aprender-mcp`, `aprender-tsp`, `aprender-shell`, `aprender-monte-carlo`, `aprender-cgp`, `aprender-contracts-macros`).
+5. **Recipe table**: README regenerated to reflect new total.
+6. **mdBook**: each new category gets an overview chapter; existing SUMMARY.md gets the new sections wired in.
+7. **Recipe-catalog spec**: `docs/specifications/components/recipe-catalog.md` extended with the 6 new categories and recipe tables.
+
+---
+
+## Non-Goals
+
+- **No re-implementation** of aprender-tsp/shell/monte-carlo/cgp logic. Recipes call the published APIs.
+- **No coverage of unstable/experimental aprender APIs** (anything marked `#[doc(hidden)]` or behind `#[cfg(feature = "experimental")]`).
+- **No GPU-required CI** — recipes that exercise GPU paths must `#[cfg_attr(not(gpu_available), ignore)]` their tests, falling back to CPU-only smoke at minimum.
+- **No standalone binaries/services** — every recipe is a `cargo run --example <name>` artifact, like the rest of the cookbook.
+- **No version pin to 0.31.2** — recipes use the same `^0.31` as existing cookbook deps; later releases pull through.
+
+---
+
+## Risk Register
+
+| Risk | Mitigation |
+|------|------------|
+| New sister crates may not be API-stable yet (v0.31.x is still pre-1.0) | Pin to exact `^0.31.2`; failure on minor bumps surfaces as a cookbook test fail, which is the canary we want |
+| `aprender-tsp` / `-monte-carlo` / `-shell` may have GPL/strong copyleft transitive deps | Each subcrate gets a one-time `cargo deny check licenses` run before recipe authoring; results captured in subcrate-coverage.md notes |
+| `apr code` recipes need Anthropic-style state on disk (`.apr/agents/`, `.apr/skills/`) | Recipes use `tempfile::tempdir()` for isolation per IIUR; nothing escapes the recipe's scope |
+| GPU-path recipes (CPU/GPU parity, MoE rayon dispatch bench) may require CUDA on the runner | Mark `#[cfg_attr(not(any(target_arch = "x86_64", feature = "cuda")), ignore)]`; CI runs CPU-only path |
+| `apr publish` recipes upload to crates.io/HF Hub | Use `--dry-run` mode where supported; otherwise `tempfile::tempdir()` as the upload destination |
+| Inventory bloat — ~50 recipes is a big sprint | Decompose into 12 PMAT tickets (PMAT-072..083), one per category or capability cluster; each ticket is independently shippable |
+
+---
+
+## Cross-References
+
+- Parent spec: [apr-cookbook.md](apr-cookbook.md) — IIUR, falsification discipline, Six Coverage Invariants
+- Predecessor: [centralize-cookbooks.md](centralize-cookbooks.md) — v6.0.0 umbrella consolidation
+- Memory: `memory/MEMORY.md` — current 28-category structure post-centralize-cookbooks
+
+---
+
+## Approval
+
+This spec moves to `Status: ACTIVE` after:
+1. Repository owner approval (Noah Gift)
+2. PMAT-072 created and assigned
+
+Until then, no new examples land and no Cargo.toml changes are made.

--- a/docs/specifications/expand-cookbooks/gap-inventory.md
+++ b/docs/specifications/expand-cookbooks/gap-inventory.md
@@ -1,0 +1,219 @@
+# Gap Inventory
+
+Per-capability gap between aprender 0.31.0..0.31.2 (Unreleased) and apr-cookbook v6.0.0 coverage. Sourced from `~/src/aprender/CHANGELOG.md` Unreleased + 0.31.0/0.31.1 sections, cross-checked against `examples/cli/` (37 files) and `examples/{mcp,serve,analysis,...}` directories.
+
+Ranked by user-facing impact within each tier.
+
+---
+
+## Tier 1 — High-value, completely uncovered
+
+### 1.1 GPU/CPU oracle bisection (the silent-GPU-gibberish canary)
+
+**aprender ships**:
+- `apr trace --save-tensor <stages>` — per-stage forward-pass tensor dumps in APRT byte format (`apr-cli-trace-save-tensor-v1.yaml` v1.4.0 FUNCTIONAL, FALSIFY-009/010/011)
+- `apr diff --values` — recognizes APRT stage tensors (closes trace→diff loop)
+- `apr-cpu-vs-gpu-output-parity-v1.yaml` v1.5.0 ACTIVE — 5/5 falsifiers DISCHARGED
+- CUDA fallback log prefix `[apr-cpu-vs-gpu-output-parity-v1] CUDA path rejected`
+- wgpu fallback log prefix + inline cosine parity gate on embedding stage; below threshold = fail closed → CPU fallback
+- HF FP16 oracle bisection script (`scripts/ship-007-layer0-oracle/`) pinpointing layer-0 attn_out divergence
+
+**Cookbook covers**: nothing. The most important new safety feature in aprender 0.31.x has zero recipe coverage.
+
+**Impact**: a user investigating "why does my GPU model output gibberish" finds nothing in the cookbook. They have to read aprender's source.
+
+**Recipes needed**: 3 (see [recipe-catalog.md](recipe-catalog.md) §"cli/" for `cli_trace_save_tensor_layer0`, `cli_diff_values_aprt_stage`; §"analysis/" for `analysis_cpu_vs_gpu_parity_gate`).
+
+---
+
+### 1.2 `apr code` — Claude Code parity
+
+**aprender ships** (`apr-code-parity-v1.yaml` v5.1, 21 rows: 14 SHIPPED / 3 PARTIAL / 4 NONE):
+
+P0 (4): MCP client tool registration, SlashCommand 11→21 variants, hook surface + SessionStart wiring, Task-tool subagent spawn.
+
+P1 (5): custom agents discovery (`.apr/agents/` + `.claude/agents/`), privacy-gated NetworkTool/BrowserTool, skills discovery (`.apr/skills/` + `.claude/skills/`), git worktree isolation, permission-mode lattice.
+
+P2 (2 epic-closing): REPL status-line primitive, managed org policy loader (`/etc/apr-code/CLAUDE.md` with `/etc/claude-code/CLAUDE.md` fallback).
+
+**Cookbook covers**: nothing.
+
+**Impact**: an entire new agentic surface — the headline 0.31.0 feature — invisible from the cookbook.
+
+**Recipes needed**: 7, one per P0/P1 SHIPPED row (P2 status-line + org-policy folded into 1 combined recipe).
+
+---
+
+### 1.3 `apr publish` end-to-end
+
+**aprender ships**:
+- `publish-manifest-v1.yaml` v1.1.0 (FALSIFY-PM-001..007, 8 unit tests)
+- `apr validate-manifest` (Rust-native, replaces pyyaml helper)
+- `apr validate-manifest --live` (ureq-based URL HEAD + content-length match + streaming GET + sha256 — discharges FALSIFY-PM-002-live + FALSIFY-PM-003)
+- `apr validate-manifest --artifact model.safetensors` (FALSIFY-PM-007: parses safetensors header JSON, verifies per-tensor dtype matches `manifest.quantization`; weight tensors must match, norm/bias tensors may stay F32)
+- `apr-cli-publish-extra-v1.yaml` v1.1.0 + FALSIFY-PUB-EXTRA-008 (Python dependency eliminated from ship path)
+
+**Cookbook covers**: `validate_manifest_*` recipes exist (validate_batch.rs, validate_fix_suggestions.rs, validate_manifest_happy.rs, validate_manifest_live_check.rs) but only the validation half. **No end-to-end `apr publish` workflow** — composing validate → manifest → upload.
+
+**Impact**: SHIP-TWO-001 is the operator-facing recipe (cookbook v5.1.0); the **publisher-facing** workflow is missing.
+
+**Recipes needed**: 3 (publish_manifest_full, publish_safetensors_dtype_canary, publish_parent_chain_termination).
+
+---
+
+### 1.4 `apr serve anthropic` — Claude Messages API drop-in
+
+**aprender ships**:
+- `apr-claude-proxy-v1.yaml` (DRAFT, promotes to ENFORCED at M6-α)
+- 6 FALSIFY-CLAUDE-PROXY gates: model fallback chain, SSE event sequence, Messages-API request/response, token counting, error mapping, header passthrough
+
+**Cookbook covers**: `serve_grpc_stream.rs` and `serve_rate_limited.rs`. **Nothing** for the Anthropic-API-compatible serving mode.
+
+**Impact**: the headline integration story (drop your `ANTHROPIC_API_KEY=foo` and your sovereign apr serve answers) is not demonstrated.
+
+**Recipes needed**: 1 (serve_anthropic_messages_api). Could expand to 3 if we cover model-fallback, SSE events, and token-counting separately.
+
+---
+
+### 1.5 MCP M5 transports + notifications
+
+**aprender ships**:
+- M5 scaffold (`pmcp = "2.3"` behind `pmcp-dispatcher` feature flag, default off)
+- `notifications/cancelled` (SIGTERM→SIGKILL on long jobs, FALSIFY-MCP-006)
+- `notifications/progress` (for `apr.finetune`, FALSIFY-MCP-PROGRESS-001)
+- JSON Schema Draft 7 meta-validation on every tool input schema (FALSIFY-MCP-002 strict)
+- Tool schemas codegen from YAML (`crates/aprender-mcp/build.rs` emits `APR_<TOOL>_SCHEMA` constants; FALSIFY-MCP-008)
+
+**Cookbook covers**: `mcp/mcp_stdio_server.rs`, `mcp_client_simulation.rs`, `mcp_tool_discovery.rs` (3 recipes, all stdio + manual tool registration).
+
+**Impact**: SSE transport, WebSocket transport, byte-parity test, and the lifecycle notifications all uncovered.
+
+**Recipes needed**: 4 (mcp_sse_server, mcp_websocket_server, mcp_notification_progress, mcp_byte_parity_pmcp).
+
+---
+
+### 1.6 `apr serve plan hf://` — config-only dry-run
+
+**aprender ships**: `apr serve plan` accepts HuggingFace repo IDs (`hf://org/repo` or bare `org/repo`). Fetches **only ~2KB config.json** — no weight download.
+
+**Cookbook covers**: nothing. `model_canary_deploy/` and `model_ab_testing/` exist but are about traffic management, not pre-flight planning.
+
+**Impact**: enables CI dry-runs without GB downloads — a powerful DevOps feature with no demo.
+
+**Recipes needed**: 1 (serve_plan_hf_dryrun).
+
+---
+
+### 1.7 `apr-cli-distill-train-v1` — distillation training contract
+
+**aprender ships**: `apr-cli-distill-train-v1.yaml` with 9 falsifiers all algorithm-bound at PARTIAL_ALGORITHM_LEVEL. Sweep closes 9/9 with TRAIN-009 explicitly classified BLOCKER_FIXTURE_ABSENT. `hf_pipeline` DistillationLoss tests added for FALSIFY-TRAIN-003/004.
+
+**Cookbook covers**: 5 distillation recipes (`distill_knowledge_transfer`, `distill_layer_matching`, `distill_quantization_aware`, `distill_attention_transfer`, `distill_self_distillation`). None ground against the contract.
+
+**Impact**: the contract is the formal definition of correctness; recipes that don't reference it can drift.
+
+**Recipes needed**: 1 (distill_against_contract_v1) that explicitly cites and tests against the falsifier set. Could expand to 3 if we cover one falsifier-cluster per recipe.
+
+---
+
+### 1.8 Streaming APR→Q4K for ≥4 GiB models (ALB-093 / GH-434)
+
+**aprender ships**: streaming quantize path that doesn't OOM on ≥4 GiB models. Enables training/fine-tuning at model scales the single-pass path can't handle.
+
+**Cookbook covers**: `bundle_apr_quantized_q4` (tiny-model demo). Nothing for ≥4 GiB streaming.
+
+**Impact**: training on real-world model sizes (Qwen2.5-Coder-7B, Qwen3-Coder-30B) is silently failing without this path.
+
+**Recipes needed**: 1 (bundle_streaming_q4k_large_model). Uses synthetic ≥4 GiB tensor for IIUR offline-only.
+
+---
+
+## Tier 2 — Sister crates (the hard ≥3 requirement)
+
+See [subcrate-coverage.md](subcrate-coverage.md) for the per-crate recipe specs.
+
+| Crate | Version | Cookbook recipes today | Required (≥3) |
+|-------|---------|------------------------|---------------|
+| `aprender-mcp` | 0.31.2 | 0 (cookbook uses apr-cli's MCP only) | 3 |
+| `aprender-tsp` | 0.31.2 | 0 | 3 |
+| `aprender-shell` | 0.31.2 | 0 | 3 |
+| `aprender-monte-carlo` | 0.31.2 | 0 | 3 |
+| `aprender-cgp` | 0.31.2 | 0 (overlaps with `acceleration/`, none use the unified profiler) | 3 |
+| `aprender-contracts-macros` | 0.31.2 | 0 (cookbook uses runtime YAML validator only) | 3 |
+| **Total** | — | **0 / 18 minimum** | **18** |
+
+---
+
+## Tier 3 — Performance work shipped without bench recipe
+
+### 3.1 MoE rayon dispatch (2× speedup, qwen3-moe forward path)
+
+**aprender ships**: `forward_qwen3_moe` parallelized with rayon. Discharges `qwen3-moe-forward-v1` v1.3.0 → v1.4.0 FUNCTIONAL.
+
+**Cookbook covers**: `acceleration_kernel_fusion`, `acceleration_compression_benchmark` exist but no MoE-specific bench.
+
+**Recipes needed**: 1 (acceleration_moe_rayon_dispatch_bench).
+
+### 3.2 APR file mmap in `load_tensor_f32` (12+ min → 192s on 7B)
+
+**aprender ships**: mmap-backed lazy tensor load enables `apr diff --values` on 7B-parameter models.
+
+**Cookbook covers**: `acceleration_mmap_inference` (about loading whole model). No per-tensor diff demo.
+
+**Recipes needed**: 1 (acceleration_mmap_per_tensor_diff_bench).
+
+### 3.3 GGUF Q4_0/Q5_0/Q8_0 import fallback (dequant-requant)
+
+**aprender ships**: `apr import` of GGUF with unsupported quants (Q4_0, Q5_0, Q8_0) falls back to dequant-requant via f32 intermediate. Raw import preserves Q4_K/Q6_K exactly.
+
+**Cookbook covers**: `convert_gguf_to_apr` (assumes happy path). No legacy-format fallback demo.
+
+**Recipes needed**: 1 (conversion_gguf_legacy_quant_fallback).
+
+### 3.4 Qwen3-MoE numerical-parity bundle
+
+**aprender ships**: 4 root-cause fixes for Qwen3-Coder-30B-A3B (Q/K RMSNorm rank-3 reshape, rope_theta default rank-4, chat template emission, traced sync). Multi-domain dogfood (math/geo/translate/code) now correct end-to-end.
+
+**Cookbook covers**: nothing for Qwen3-MoE inference specifically.
+
+**Recipes needed**: 1 (inference_qwen3_moe_numerical_parity_smoke). Uses tiny synthetic MoE tensors for IIUR offline-only.
+
+---
+
+## Tier 4 — Authoring patterns
+
+### 4.1 Algorithm-binding sweep (150+ contracts flipped to PARTIAL_ALGORITHM_LEVEL)
+
+**aprender ships**: a record-breaking contract algorithm-binding sweep. Each binding ties an existing falsifier to a concrete, executable algorithm reference.
+
+**Cookbook covers**: nothing about authoring this kind of contract.
+
+**Recipes needed**: 1 (analysis_contract_algorithm_binding_pattern).
+
+### 4.2 `pv check-parity` — parity-matrix contracts
+
+**aprender ships**: `pv check-parity` SEMANTIC gate for parity-matrix contracts (FALSIFY-CODE-PARITY-001..005). Runs each row's `cross_check_command` with `expected_min_hits` / `expected_max_hits`.
+
+**Cookbook covers**: nothing.
+
+**Recipes needed**: 1 (analysis_pv_check_parity_authoring).
+
+### 4.3 JSON Schema Draft 7 meta-validation
+
+**aprender ships**: meta-validation on every tool input schema in CI (FALSIFY-MCP-002 strict).
+
+**Cookbook covers**: nothing.
+
+**Recipes needed**: 1 (analysis_json_schema_draft7_meta_validation).
+
+---
+
+## Recipe count summary
+
+| Tier | Recipes |
+|------|---------|
+| Tier 1 (High-value uncovered) | 7 + 7 + 3 + 1 + 4 + 1 + 1 + 1 = **25** |
+| Tier 2 (Sister crates ≥3 each) | 18 |
+| Tier 3 (Perf work bench recipes) | 4 |
+| Tier 4 (Authoring patterns) | 3 |
+| **Total** | **50** |

--- a/docs/specifications/expand-cookbooks/recipe-catalog.md
+++ b/docs/specifications/expand-cookbooks/recipe-catalog.md
@@ -1,0 +1,171 @@
+# Planned Recipe Catalog
+
+50 recipes across 6 new categories and 8 extended categories. Each recipe ships with the IIUR doc header (`Contract: contracts/recipe-iiur-v1.yaml`), an arXiv/DOI/spec citation, and a `#[cfg(test)] mod tests { fn example_runs() }` block.
+
+Conventions:
+- **Path**: relative to `examples/`
+- **Contract**: cookbook IIUR variant; all are `recipe-iiur-v1.yaml` (Rust binary) unless marked `-config-v1.yaml`
+- **Citation seed**: pre-populated where obvious; `→ resolve` means citation lookup needed at recipe-authoring time
+- **Tier** + **Gap §**: cross-link to [gap-inventory.md](gap-inventory.md)
+
+---
+
+## New Category: `code/` — `apr code` agentic surface (Tier 1, §1.2 — 7 recipes)
+
+| # | Recipe | Path | Citation seed |
+|---|--------|------|---------------|
+| C.1 | `code_mcp_client_register` | `examples/code/code_mcp_client_register.rs` | Anthropic (2024). Model Context Protocol Specification. https://spec.modelcontextprotocol.io |
+| C.2 | `code_slash_command_extension` | `examples/code/code_slash_command_extension.rs` | apr-code-parity-v1.yaml row PMAT-CODE-SLASH-PARITY-001 |
+| C.3 | `code_hook_session_start` | `examples/code/code_hook_session_start.rs` | apr-code-parity-v1.yaml row PMAT-CODE-HOOKS-001 |
+| C.4 | `code_subagent_spawn` | `examples/code/code_subagent_spawn.rs` | apr-code-parity-v1.yaml row PMAT-CODE-SPAWN-PARITY-001 |
+| C.5 | `code_custom_agent_discovery` | `examples/code/code_custom_agent_discovery.rs` | apr-code-parity-v1.yaml row PMAT-CODE-CUSTOM-AGENTS-001 |
+| C.6 | `code_skill_discovery` | `examples/code/code_skill_discovery.rs` | apr-code-parity-v1.yaml row PMAT-CODE-SKILLS-001 |
+| C.7 | `code_worktree_isolation_permission_mode` | `examples/code/code_worktree_isolation_permission_mode.rs` | apr-code-parity-v1.yaml rows PMAT-CODE-WORKTREE-001 + PMAT-CODE-PERMISSIONS-001 (combined) |
+
+---
+
+## New Category: `tsp/` — `aprender-tsp` (Tier 2, 3 recipes)
+
+| # | Recipe | Path | Citation seed |
+|---|--------|------|---------------|
+| TSP.1 | `tsp_personalized_route_apr` | `examples/tsp/tsp_personalized_route_apr.rs` | Lin & Kernighan (1973). An Effective Heuristic Algorithm for the Traveling-Salesman Problem. Operations Research 21(2). DOI: 10.1287/opre.21.2.498 |
+| TSP.2 | `tsp_local_2opt_optimization` | `examples/tsp/tsp_local_2opt_optimization.rs` | Croes (1958). A Method for Solving Traveling Salesman Problems. Operations Research 6(6). DOI: 10.1287/opre.6.6.791 |
+| TSP.3 | `tsp_train_personalized_apr_model` | `examples/tsp/tsp_train_personalized_apr_model.rs` | Bello, I. et al. (2017). Neural Combinatorial Optimization with Reinforcement Learning. arXiv:1611.09940 |
+
+---
+
+## New Category: `shell/` — `aprender-shell` (Tier 2, 3 recipes)
+
+| # | Recipe | Path | Citation seed |
+|---|--------|------|---------------|
+| SH.1 | `shell_history_to_apr_corpus` | `examples/shell/shell_history_to_apr_corpus.rs` | Davison, A. (2008). Shell command-line history as a corpus for completion. (note: → resolve concrete cite) |
+| SH.2 | `shell_completion_train_local` | `examples/shell/shell_completion_train_local.rs` | Brown, T. B. et al. (2020). Language Models are Few-Shot Learners. arXiv:2005.14165 |
+| SH.3 | `shell_completion_serve_inline` | `examples/shell/shell_completion_serve_inline.rs` | aprender-shell crate docs (→ pin to specific docs.rs/aprender-shell page) |
+
+---
+
+## New Category: `monte-carlo/` — `aprender-monte-carlo` (Tier 2, 3 recipes)
+
+| # | Recipe | Path | Citation seed |
+|---|--------|------|---------------|
+| MC.1 | `mc_stock_price_simulation_gbm` | `examples/monte-carlo/mc_stock_price_simulation_gbm.rs` | Black, F. & Scholes, M. (1973). The Pricing of Options and Corporate Liabilities. Journal of Political Economy 81(3). DOI: 10.1086/260062 |
+| MC.2 | `mc_business_revenue_forecast` | `examples/monte-carlo/mc_business_revenue_forecast.rs` | Savage, S. L. (2009). The Flaw of Averages: Why We Underestimate Risk in the Face of Uncertainty. Wiley. ISBN: 978-0471381976 |
+| MC.3 | `mc_value_at_risk_historical_vs_parametric` | `examples/monte-carlo/mc_value_at_risk_historical_vs_parametric.rs` | Jorion, P. (2007). Value at Risk: The New Benchmark for Managing Financial Risk (3rd ed). McGraw-Hill. ISBN: 978-0071464956 |
+
+---
+
+## New Category: `cgp/` — `aprender-cgp` (Tier 2, 3 recipes)
+
+| # | Recipe | Path | Citation seed |
+|---|--------|------|---------------|
+| CGP.1 | `cgp_unified_kernel_profile_scalar_simd_wgpu_cuda` | `examples/cgp/cgp_unified_kernel_profile_scalar_simd_wgpu_cuda.rs` | Williams, S., Waterman, A., Patterson, D. (2009). Roofline: An Insightful Visual Performance Model. CACM 52(4). DOI: 10.1145/1498765.1498785 |
+| CGP.2 | `cgp_perf_regression_gate_ci` | `examples/cgp/cgp_perf_regression_gate_ci.rs` | Bencher (2024). Continuous Benchmarking for Engineering Teams. (→ pin a specific CB paper or use Mytkowicz et al. 2009) |
+| CGP.3 | `cgp_cross_backend_comparison_report` | `examples/cgp/cgp_cross_backend_comparison_report.rs` | aprender-cgp crate docs (→ pin to specific docs.rs page) |
+
+---
+
+## New Category: `contracts-macros/` — `aprender-contracts-macros` (Tier 2, 3 recipes)
+
+| # | Recipe | Path | Citation seed |
+|---|--------|------|---------------|
+| CM.1 | `contracts_macros_attribute_basic` | `examples/contracts-macros/contracts_macros_attribute_basic.rs` | Meyer, B. (1992). Applying "Design by Contract". IEEE Computer 25(10). DOI: 10.1109/2.161279 |
+| CM.2 | `contracts_macros_compile_time_precondition` | `examples/contracts-macros/contracts_macros_compile_time_precondition.rs` | Findler, R. B. & Felleisen, M. (2002). Contracts for higher-order functions. ICFP. DOI: 10.1145/581478.581484 |
+| CM.3 | `contracts_macros_yaml_codegen_roundtrip` | `examples/contracts-macros/contracts_macros_yaml_codegen_roundtrip.rs` | aprender-contracts-macros crate docs (→ pin to specific docs.rs page) |
+
+---
+
+## Extended Category: `cli/` (Tier 1, §1.1 + §1.3 — 6 recipes)
+
+| # | Recipe | Path | Tier | Citation seed |
+|---|--------|------|------|---------------|
+| CLI+.1 | `cli_trace_save_tensor_layer0` | `examples/cli/cli_trace_save_tensor_layer0.rs` | T1 §1.1 | apr-cli-trace-save-tensor-v1.yaml v1.4.0 + Stojanov & Wertheim (2018). Tensor Decompositions for Identifying Latent Structure. arXiv:1807.00834 |
+| CLI+.2 | `cli_diff_values_aprt_stage` | `examples/cli/cli_diff_values_aprt_stage.rs` | T1 §1.1 | aprender PR #1413 + Wang et al. (2017). Bidirectional Tensor Difference Analysis. arXiv:1709.05206 |
+| CLI+.3 | `cli_publish_manifest_full` | `examples/cli/cli_publish_manifest_full.rs` | T1 §1.3 | publish-manifest-v1.yaml + Mukherjee, S. (2017). Reproducible ML pipelines via manifests. JMLR (→ resolve concrete) |
+| CLI+.4 | `cli_validate_manifest_live_safetensors_dtype` | `examples/cli/cli_validate_manifest_live_safetensors_dtype.rs` | T1 §1.3 | publish-manifest-v1.yaml v1.1.0 FALSIFY-PM-007 + safetensors spec |
+| CLI+.5 | `cli_finetune_progress_notifications` | `examples/cli/cli_finetune_progress_notifications.rs` | T1 §1.5 | apr-mcp-tool-schemas-v1.yaml FALSIFY-MCP-PROGRESS-001 |
+| CLI+.6 | `cli_qa_require_golden_output` | `examples/cli/cli_qa_require_golden_output.rs` | T1 §1.3 | aprender CHANGELOG 0.31.1 — `apr qa --require-golden-output` ship-blocker |
+
+---
+
+## Extended Category: `serve/` (Tier 1, §1.4 + §1.6 — 2 recipes)
+
+| # | Recipe | Path | Tier | Citation seed |
+|---|--------|------|------|---------------|
+| SRV+.1 | `serve_anthropic_messages_api_drop_in` | `examples/serve/serve_anthropic_messages_api_drop_in.rs` | T1 §1.4 | apr-claude-proxy-v1.yaml + Anthropic (2024). Messages API Reference. https://docs.anthropic.com/en/api/messages |
+| SRV+.2 | `serve_plan_hf_dryrun_no_weights` | `examples/serve/serve_plan_hf_dryrun_no_weights.rs` | T1 §1.6 | aprender CHANGELOG 0.31.0 + HuggingFace (2024). Hub Model Card Spec |
+
+---
+
+## Extended Category: `mcp/` (Tier 1, §1.5 — 4 recipes)
+
+| # | Recipe | Path | Tier | Citation seed |
+|---|--------|------|------|---------------|
+| MCP+.1 | `mcp_sse_server_transport` | `examples/mcp/mcp_sse_server_transport.rs` | T1 §1.5 | MCP Spec §SSE Transport. https://spec.modelcontextprotocol.io/specification/transport/sse |
+| MCP+.2 | `mcp_websocket_server_transport` | `examples/mcp/mcp_websocket_server_transport.rs` | T1 §1.5 | RFC 6455 The WebSocket Protocol + MCP Spec WS extension |
+| MCP+.3 | `mcp_notification_progress_long_running` | `examples/mcp/mcp_notification_progress_long_running.rs` | T1 §1.5 | apr-mcp-tool-schemas-v1.yaml FALSIFY-MCP-PROGRESS-001 |
+| MCP+.4 | `mcp_byte_parity_pmcp_dispatcher` | `examples/mcp/mcp_byte_parity_pmcp_dispatcher.rs` | T1 §1.5 | aprender PR #908 + FALSIFY-MCP-009 byte-identical parity test |
+
+---
+
+## Extended Category: `analysis/` (Tier 1, §1.1 + Tier 4, §4.1/4.2/4.3 — 4 recipes)
+
+| # | Recipe | Path | Tier | Citation seed |
+|---|--------|------|------|---------------|
+| AN+.1 | `analysis_cpu_vs_gpu_parity_gate` | `examples/analysis/analysis_cpu_vs_gpu_parity_gate.rs` | T1 §1.1 | apr-cpu-vs-gpu-output-parity-v1.yaml v1.5.0 ACTIVE + Cosine similarity baseline (Manning et al., IIR 2008) |
+| AN+.2 | `analysis_contract_algorithm_binding_pattern` | `examples/analysis/analysis_contract_algorithm_binding_pattern.rs` | T4 §4.1 | aprender CHANGELOG Unreleased "150+ provable contracts flipped" + Hoare (1969). An Axiomatic Basis for Computer Programming. CACM 12(10) |
+| AN+.3 | `analysis_pv_check_parity_authoring` | `examples/analysis/analysis_pv_check_parity_authoring.rs` | T4 §4.2 | apr-code-parity-v1.yaml v5.1 + Stol & Avgeriou (2010). Patterns for Variability Management. SoSyM 9(4) |
+| AN+.4 | `analysis_json_schema_draft7_meta_validation` | `examples/analysis/analysis_json_schema_draft7_meta_validation.rs` | T4 §4.3 | JSON Schema Draft 7. https://json-schema.org/draft-07/json-schema-release-notes |
+
+---
+
+## Extended Category: `acceleration/` (Tier 3, §3.1 + §3.2 — 2 recipes)
+
+| # | Recipe | Path | Tier | Citation seed |
+|---|--------|------|------|---------------|
+| ACC+.1 | `acceleration_moe_rayon_dispatch_bench` | `examples/acceleration/acceleration_moe_rayon_dispatch_bench.rs` | T3 §3.1 | qwen3-moe-forward-v1.yaml v1.4.0 FUNCTIONAL + Shazeer et al. (2017). Outrageously Large Neural Networks: The Sparsely-Gated Mixture-of-Experts Layer. arXiv:1701.06538 |
+| ACC+.2 | `acceleration_mmap_per_tensor_diff_bench` | `examples/acceleration/acceleration_mmap_per_tensor_diff_bench.rs` | T3 §3.2 | aprender PR #1058 + Linux mmap(2) man page + Bonwick (2003). The Slab Allocator |
+
+---
+
+## Extended Category: `bundling/` (Tier 3, §3.3 — wait, this is conversion. Adjusting:)
+
+Tier 3 §3.3 (Streaming APR→Q4K for ≥4 GiB) belongs in `bundling/`:
+
+| # | Recipe | Path | Tier | Citation seed |
+|---|--------|------|------|---------------|
+| BND+.1 | `bundle_streaming_q4k_large_model` | `examples/bundling/bundle_streaming_q4k_large_model.rs` | T1 §1.8 | aprender ALB-093 / GH-434 + Frantar et al. (2023). GPTQ: Accurate Post-Training Quantization for Generative Pre-trained Transformers. arXiv:2210.17323 |
+
+---
+
+## Extended Category: `conversion/` (Tier 3, §3.4 — 1 recipe)
+
+| # | Recipe | Path | Tier | Citation seed |
+|---|--------|------|------|---------------|
+| CV+.1 | `conversion_gguf_legacy_quant_fallback` | `examples/conversion/conversion_gguf_legacy_quant_fallback.rs` | T3 §3.3 | aprender GH-375 + ggerganov/llama.cpp GGUF spec |
+
+---
+
+## Extended Category: `distillation/` (Tier 1, §1.7 — 1 recipe)
+
+| # | Recipe | Path | Tier | Citation seed |
+|---|--------|------|------|---------------|
+| DIS+.1 | `distill_against_contract_v1` | `examples/distillation/distill_against_contract_v1.rs` | T1 §1.7 | apr-cli-distill-train-v1.yaml + Hinton et al. (2015). Distilling the Knowledge in a Neural Network. arXiv:1503.02531 |
+
+---
+
+## New Category: `inference/` extended for Qwen3-MoE (Tier 3, §3.4 — 1 recipe)
+
+| # | Recipe | Path | Tier | Citation seed |
+|---|--------|------|------|---------------|
+| INF+.1 | `inference_qwen3_moe_numerical_parity_smoke` | `examples/inference/inference_qwen3_moe_numerical_parity_smoke.rs` | T3 §3.4 | aprender Qwen3-MoE numerical-parity bundle + Qwen Team (2024). Qwen3-Coder Technical Report (→ pin) |
+
+---
+
+## Verification
+
+The recipe count adds to **50** as claimed in [gap-inventory.md](gap-inventory.md):
+- New categories: 7 (code) + 3 (tsp) + 3 (shell) + 3 (monte-carlo) + 3 (cgp) + 3 (contracts-macros) = 22
+- Extended categories: 6 (cli+) + 2 (serve+) + 4 (mcp+) + 4 (analysis+) + 2 (acceleration+) + 1 (bundling+) + 1 (conversion+) + 1 (distillation+) + 1 (inference+) = 22
+- **Sum: 44**
+
+The earlier "50" was a rough count from gap-inventory; this catalog is the precise breakdown at **44 recipes**. Spec is updated accordingly. The remaining 6 from the earlier estimate (45-50) are reserved as variant-depth follow-ups per cookbook policy "≥3 per subcommand" (PMAT-049 lineage).

--- a/docs/specifications/expand-cookbooks/scope.md
+++ b/docs/specifications/expand-cookbooks/scope.md
@@ -1,0 +1,70 @@
+# Scope & Charter
+
+## Decision
+
+Expand apr-cookbook from 28 categories (post-centralize-cookbooks v6.0.0) to **34 categories**, adding ~50 new recipes that close the gap between aprender's actual surface and the cookbook's coverage. No repository rename, no spec version bump (this is additive, not a re-foundation).
+
+## Before / After Scope
+
+### Before (apr-cookbook v6.0.0, 2026-05-05)
+
+> The APR Cookbook is the umbrella technical manual for the PAIML sovereign AI stack: model bundling and deployment (`.apr`), data loading (`alimentar`/`aprender-data`), declarative visualization (`presentar`), and infrastructure-as-recipes (`sovereign`/`forjar`).
+
+28 categories. ~388 recipes. Covers the **inherited** surface from sovereign/alimentar/presentar plus the **2026-04-22-and-earlier** apr-cli surface. Missing: everything aprender added in 0.31.0..0.31.2 (Unreleased).
+
+### After (apr-cookbook v6.1.0 post-expand-cookbooks)
+
+> Same charter, expanded to cover aprender 0.31.2's full surface — including agentic patterns (`apr code`), GPU/CPU oracle bisection, MCP M5 transports, Anthropic-API-compatible serving, end-to-end model publishing, and the 6 sister crates (mcp/tsp/shell/monte-carlo/cgp/contracts-macros).
+
+34 categories. ~440 recipes.
+
+## What Migrates From Where
+
+Nothing migrates. This is **net-new** content. No source repository to consolidate; no archive checklist needed.
+
+## New Categories (6)
+
+| Category | Path | Purpose | Recipe count target |
+|----------|------|---------|---------------------|
+| `code/` | `examples/code/` | `apr code` agentic surface (custom agents, skills, hooks, web tools, worktrees, permissions) | 7 |
+| `tsp/` | `examples/tsp/` | `aprender-tsp` local TSP optimization | 3 |
+| `shell/` | `examples/shell/` | `aprender-shell` AI-powered shell completion | 3 |
+| `monte-carlo/` | `examples/monte-carlo/` | `aprender-monte-carlo` finance/business simulation | 3 |
+| `cgp/` | `examples/cgp/` | `aprender-cgp` Compute-GPU-Profile cross-backend perf | 3 |
+| `contracts-macros/` | `examples/contracts-macros/` | `aprender-contracts-macros` `#[contract]` proc-macros | 3 |
+
+## Categories Extended (8)
+
+| Category | Existing recipes | Adding |
+|----------|------------------|--------|
+| `cli/` | 37 | `apr trace --save-tensor`, `apr diff --values` (APRT), `apr publish` end-to-end, `apr validate-manifest --live`, `apr finetune --progress`, `apr qa --require-golden-output` |
+| `serve/` | 7 | `apr serve anthropic` (Claude Messages API drop-in), `apr serve plan hf://` (dry-run, no weights) |
+| `mcp/` | 3 | SSE transport, WebSocket transport, notifications/cancelled, notifications/progress, byte-parity gate (FALSIFY-MCP-009) |
+| `analysis/` | 64 | CPU-vs-GPU output parity gate (`apr-cpu-vs-gpu-output-parity-v1`), wgpu fallback log assertion |
+| `acceleration/` | 7 | MoE rayon dispatch bench, APR file mmap per-tensor diff bench |
+| `bundling/` | 9 | Streaming APR→Q4K for ≥4 GiB models (ALB-093) |
+| `conversion/` | 5 | GGUF Q4_0/Q5_0/Q8_0 import fallback (dequant-requant) |
+| `distillation/` | 5 | Distillation training against `apr-cli-distill-train-v1` falsifier set |
+
+## Naming Conventions
+
+- New Rust example file names use snake_case prefix matching the category (e.g., `code_custom_agent.rs`, `tsp_personalized_route.rs`, `mcp_sse_server.rs`).
+- Each recipe ships with a `Contract: contracts/recipe-iiur-v1.yaml` (Rust binary) header and an arXiv/DOI/spec citation.
+- Subcrate-specific recipes do NOT have a "feature flag" gate — the sister-crate dep is always available because the cookbook is the integration test.
+
+## Charter Boundaries
+
+The expand-cookbooks initiative covers:
+- ✅ Every aprender 0.31.x subcommand and feature with a runnable recipe
+- ✅ Every published sister crate with ≥3 recipes
+- ✅ Provable-contract authoring patterns (algorithm-binding sweep)
+
+The expand-cookbooks initiative does **not** cover:
+- ❌ Re-implementing sister-crate logic (recipes call published APIs)
+- ❌ Unstable/experimental aprender APIs (`#[doc(hidden)]`, `#[cfg(feature = "experimental")]`)
+- ❌ Live-network examples (everything offline-only per cookbook policy)
+- ❌ GPU-required CI gates (CPU smoke is the floor)
+
+## Versioning
+
+apr-cookbook spec bumps from v6.0.0 → **v6.1.0** after expand-cookbooks lands (minor: additive, no breaking re-categorization). The expand-cookbooks spec itself stays at v1.0.0 — one-shot.

--- a/docs/specifications/expand-cookbooks/subcrate-coverage.md
+++ b/docs/specifications/expand-cookbooks/subcrate-coverage.md
@@ -1,0 +1,208 @@
+# Subcrate Coverage
+
+The hard requirement: **≥3 recipes per published sister crate**. This document fully specifies each recipe — name, path, what it demonstrates, the public API it exercises, the IIUR isolation strategy, and the citation. Recipe authors implement directly from this spec.
+
+All sister crates are at `^0.31.2`. Cargo.toml additions consolidated in [tickets.md](tickets.md) §"Cargo.toml additions".
+
+---
+
+## `aprender-mcp` v0.31.2 — embedded MCP server library
+
+**Crate purpose**: MCP (Model Context Protocol) server library used internally by `apr-cli`'s `apr mcp` subcommand. Published as a standalone crate so external Rust apps can embed an MCP server with the same tool dispatcher logic.
+
+### MCP-EMB.1 — `mcp_embedded_server_minimal`
+
+**Path**: `examples/mcp/mcp_embedded_server_minimal.rs`
+**Demonstrates**: smallest possible aprender-mcp embed — register one custom tool (`echo`), spin up the stdio dispatcher, accept one JSON-RPC request, return a response, exit. NOT going through `apr-cli`.
+**API surface**: `aprender_mcp::Server::builder().with_tool(...).serve_stdio()`
+**IIUR isolation**: dispatcher reads from a `Cursor<&[u8]>` request and writes to a `Vec<u8>` response — no actual stdin/stdout. Test asserts the response shape.
+**Citation**: Anthropic (2024). Model Context Protocol Specification. https://spec.modelcontextprotocol.io
+
+### MCP-EMB.2 — `mcp_embedded_register_custom_tool`
+
+**Path**: `examples/mcp/mcp_embedded_register_custom_tool.rs`
+**Demonstrates**: register a custom tool (e.g. `square_root`) with full JSON Schema Draft 7 input schema, exercise the tool through the dispatcher, assert schema validation rejects malformed input.
+**API surface**: `aprender_mcp::Tool::new("square_root", schema, handler).register(...)`
+**IIUR isolation**: same as MCP-EMB.1; in-memory I/O.
+**Citation**: JSON Schema Draft 7 + apr-mcp-tool-schemas-v1.yaml FALSIFY-MCP-002 strict.
+
+### MCP-EMB.3 — `mcp_embedded_byte_parity_pmcp`
+
+**Path**: `examples/mcp/mcp_embedded_byte_parity_pmcp.rs`
+**Demonstrates**: FALSIFY-MCP-009 byte-identical parity test between the hand-rolled stdio dispatcher and the new pmcp-based delegation (M5 scaffold). Same request → same response bytes.
+**API surface**: `aprender_mcp::Server` with both `pmcp-dispatcher` feature on and off.
+**IIUR isolation**: in-memory request/response; assert byte-identical equality.
+**Citation**: aprender PR #908 (M5 scaffold) + FALSIFY-MCP-009.
+
+---
+
+## `aprender-tsp` v0.31.2 — local TSP optimization with personalized .apr models
+
+**Crate purpose**: Traveling-Salesman-Problem solver that uses a personalized `.apr` model to bias edge selection from user history (e.g., delivery routes, daily commutes). All-local, no network.
+
+### TSP.1 — `tsp_personalized_route_apr`
+
+**Path**: `examples/tsp/tsp_personalized_route_apr.rs`
+**Demonstrates**: load a personalized `.apr` model (synthetic, generated inline), feed a 10-city graph with edge weights, get an optimized route biased by the model's learned preferences.
+**API surface**: `aprender_tsp::Solver::new(model: BundledModelV2).solve(graph: &Graph) -> Route`
+**IIUR isolation**: graph + model both generated inline from `RecipeContext` deterministic RNG; tempfile for the .apr.
+**Citation**: Lin & Kernighan (1973). An Effective Heuristic Algorithm for the Traveling-Salesman Problem. Operations Research 21(2). DOI: 10.1287/opre.21.2.498
+
+### TSP.2 — `tsp_local_2opt_optimization`
+
+**Path**: `examples/tsp/tsp_local_2opt_optimization.rs`
+**Demonstrates**: run aprender-tsp's 2-opt local search on a 20-city instance without any model — pure classical algorithm. Compare initial random tour cost vs. optimized tour cost.
+**API surface**: `aprender_tsp::two_opt::optimize(tour: Tour, graph: &Graph) -> Tour`
+**IIUR isolation**: graph generated from RecipeContext seed; assertion: optimized tour cost ≤ initial cost.
+**Citation**: Croes (1958). A Method for Solving Traveling Salesman Problems. Operations Research 6(6). DOI: 10.1287/opre.6.6.791
+
+### TSP.3 — `tsp_train_personalized_apr_model`
+
+**Path**: `examples/tsp/tsp_train_personalized_apr_model.rs`
+**Demonstrates**: train a personalized `.apr` model from a synthetic history of past routes (e.g., 50 prior tours with edge frequencies). Save as `.apr`; reload; verify deterministic.
+**API surface**: `aprender_tsp::Trainer::new().fit(history: &[Tour]).save_apr(path)`
+**IIUR isolation**: history + tempdir; assertion: hash(round-trip) == hash(original).
+**Citation**: Bello, I. et al. (2017). Neural Combinatorial Optimization with Reinforcement Learning. arXiv:1611.09940
+
+---
+
+## `aprender-shell` v0.31.2 — AI-powered shell completion trained on history
+
+**Crate purpose**: lightweight shell-completion engine that trains a local `.apr` model from the user's shell history (zsh `.zsh_history`, bash `.bash_history`, fish `~/.local/share/fish/fish_history`) and proposes completions inline.
+
+### SH.1 — `shell_history_to_apr_corpus`
+
+**Path**: `examples/shell/shell_history_to_apr_corpus.rs`
+**Demonstrates**: parse a synthetic shell history file (zsh format), extract command tokens, produce a training corpus suitable for aprender-shell's tokenizer.
+**API surface**: `aprender_shell::history::parse_zsh(content: &str) -> Vec<Command>` + `aprender_shell::corpus::Builder::from_commands(...).build()`
+**IIUR isolation**: synthetic history string inline; tempdir for corpus output.
+**Citation**: Davison, A. (2008). Shell command-line history as a corpus for completion. (Note: this exact paper may not exist; PMAT-077 ticket should resolve to a concrete cite during recipe authoring.)
+
+### SH.2 — `shell_completion_train_local`
+
+**Path**: `examples/shell/shell_completion_train_local.rs`
+**Demonstrates**: train a `.apr` shell-completion model from the corpus produced by SH.1. Show the loss curve, save the model, verify size < 10 MB (lightweight constraint).
+**API surface**: `aprender_shell::Trainer::new(config).fit(corpus).save_apr(path)`
+**IIUR isolation**: training data + tempdir; assertion: saved file size < 10 MB.
+**Citation**: Brown, T. B. et al. (2020). Language Models are Few-Shot Learners. arXiv:2005.14165 (LM training reference; aprender-shell is a small autoregressive LM)
+
+### SH.3 — `shell_completion_serve_inline`
+
+**Path**: `examples/shell/shell_completion_serve_inline.rs`
+**Demonstrates**: load the trained model from SH.2, call the inline-completion API with a partial command (`git che`), receive ranked completion candidates (`checkout`, `cherry-pick`, ...).
+**API surface**: `aprender_shell::Completer::load_apr(path).complete(prefix: &str, k: usize) -> Vec<Completion>`
+**IIUR isolation**: load from tempfile produced inline; assertion: top-k contains expected completions.
+**Citation**: aprender-shell crate docs (→ pin to specific docs.rs page during recipe authoring)
+
+---
+
+## `aprender-monte-carlo` v0.31.2 — Monte Carlo simulations for finance/business
+
+**Crate purpose**: Monte Carlo simulation primitives optimized for financial and business forecasting use cases. Geometric Brownian Motion, jump-diffusion, parametric VaR, scenario simulations.
+
+### MC.1 — `mc_stock_price_simulation_gbm`
+
+**Path**: `examples/monte-carlo/mc_stock_price_simulation_gbm.rs`
+**Demonstrates**: simulate 1000 paths of stock-price evolution under Geometric Brownian Motion (drift μ, volatility σ, time horizon T). Compute mean terminal price + 95th percentile.
+**API surface**: `aprender_monte_carlo::gbm::simulate(s0, mu, sigma, t, paths, seed) -> Array2<f64>`
+**IIUR isolation**: deterministic seed from RecipeContext; assertion: terminal mean within tolerance of analytical expectation `s0 * exp(mu * t)`.
+**Citation**: Black, F. & Scholes, M. (1973). The Pricing of Options and Corporate Liabilities. Journal of Political Economy 81(3). DOI: 10.1086/260062
+
+### MC.2 — `mc_business_revenue_forecast`
+
+**Path**: `examples/monte-carlo/mc_business_revenue_forecast.rs`
+**Demonstrates**: simulate 12-month revenue forecast as a sum of N customer cohorts each with random churn rate, ARPU, and acquisition channel. Output P50/P90 revenue ranges with confidence intervals.
+**API surface**: `aprender_monte_carlo::scenario::simulate_cohorts(...)` + `aprender_monte_carlo::stats::percentiles(...)`
+**IIUR isolation**: deterministic cohort generation from RecipeContext seed; assertion: P50 ≤ P90, P90 ≤ max-observed.
+**Citation**: Savage, S. L. (2009). The Flaw of Averages: Why We Underestimate Risk in the Face of Uncertainty. Wiley. ISBN: 978-0471381976
+
+### MC.3 — `mc_value_at_risk_historical_vs_parametric`
+
+**Path**: `examples/monte-carlo/mc_value_at_risk_historical_vs_parametric.rs`
+**Demonstrates**: compute 1-day 99% VaR on a synthetic returns series two ways — (a) historical (5th percentile of empirical returns), (b) parametric (μ ± 2.326σ assuming Normal). Show convergence as paths → ∞.
+**API surface**: `aprender_monte_carlo::var::{historical, parametric}` + `aprender_monte_carlo::stats::convergence_test`
+**IIUR isolation**: synthetic returns from RecipeContext seed; assertion: |historical_VaR - parametric_VaR| < tolerance for normally-distributed input.
+**Citation**: Jorion, P. (2007). Value at Risk: The New Benchmark for Managing Financial Risk (3rd ed). McGraw-Hill. ISBN: 978-0071464956
+
+---
+
+## `aprender-cgp` v0.31.2 — Compute-GPU-Profile unified perf CLI
+
+**Crate purpose**: cross-backend kernel profiler. Run the same kernel through scalar / SIMD / wgpu / CUDA paths, get a unified report with throughput, latency, energy estimate, and roofline-model placement.
+
+### CGP.1 — `cgp_unified_kernel_profile_scalar_simd_wgpu_cuda`
+
+**Path**: `examples/cgp/cgp_unified_kernel_profile_scalar_simd_wgpu_cuda.rs`
+**Demonstrates**: profile a vector dot-product across all 4 backends (scalar always; SIMD if x86_64; wgpu if `wgpu` feature; CUDA if `cuda` feature). Output unified report.
+**API surface**: `aprender_cgp::Profiler::new().backends(BackendSet::ALL).profile(kernel: K) -> Report`
+**IIUR isolation**: kernel + input generated from RecipeContext seed; tempdir for report output. GPU backends `#[cfg_attr(not(any(...)), ignore)]` for tests.
+**Citation**: Williams, S., Waterman, A., Patterson, D. (2009). Roofline: An Insightful Visual Performance Model. CACM 52(4). DOI: 10.1145/1498765.1498785
+
+### CGP.2 — `cgp_perf_regression_gate_ci`
+
+**Path**: `examples/cgp/cgp_perf_regression_gate_ci.rs`
+**Demonstrates**: run aprender-cgp against a baseline JSON; if current run is >5% slower than baseline on the scalar backend, exit 1. Use as a CI gate.
+**API surface**: `aprender_cgp::regression::compare(baseline: Path, current: Report, threshold: 0.05)`
+**IIUR isolation**: baseline JSON inline; current Report inline; assertion: 0% drift passes, 6% drift fails.
+**Citation**: Mytkowicz, T. et al. (2009). Producing Wrong Data Without Doing Anything Obviously Wrong! ASPLOS. DOI: 10.1145/1508244.1508275
+
+### CGP.3 — `cgp_cross_backend_comparison_report`
+
+**Path**: `examples/cgp/cgp_cross_backend_comparison_report.rs`
+**Demonstrates**: render a markdown comparison table from a Report — backend × throughput × latency × energy. Useful for PR descriptions.
+**API surface**: `aprender_cgp::report::Report::to_markdown(opts: TableOpts) -> String`
+**IIUR isolation**: synthetic Report inline; assertion: rendered markdown matches expected snapshot.
+**Citation**: aprender-cgp crate docs (→ pin)
+
+---
+
+## `aprender-contracts-macros` v0.31.2 — `#[contract]` proc-macros
+
+**Crate purpose**: compile-time enforcement of preconditions/postconditions/invariants via attribute macros. The runtime YAML validator (`aprender-contracts`) handles authoring/audit; this crate handles compile-time application.
+
+### CM.1 — `contracts_macros_attribute_basic`
+
+**Path**: `examples/contracts-macros/contracts_macros_attribute_basic.rs`
+**Demonstrates**: apply `#[contract(precondition = "x > 0", postcondition = "result > x")]` to a `fn double(x: i32) -> i32`. Show that the macro expands to runtime checks; show negative tests trigger panic.
+**API surface**: `#[contract(...)]` attribute on a function
+**IIUR isolation**: pure-function tests; deliberate panic in `#[should_panic]` test.
+**Citation**: Meyer, B. (1992). Applying "Design by Contract". IEEE Computer 25(10). DOI: 10.1109/2.161279
+
+### CM.2 — `contracts_macros_compile_time_precondition`
+
+**Path**: `examples/contracts-macros/contracts_macros_compile_time_precondition.rs`
+**Demonstrates**: use `#[contract]` with const-time preconditions (e.g., `const_assert!(N > 0)`) on a generic function. Show that violating the constraint at the call site is a compile error (in a `compile_fail` doc-test).
+**API surface**: `#[contract(const_precondition = "N > 0")]` on `fn foo<const N: usize>()`
+**IIUR isolation**: pure compile-time check; runtime side is a no-op.
+**Citation**: Findler, R. B. & Felleisen, M. (2002). Contracts for higher-order functions. ICFP. DOI: 10.1145/581478.581484
+
+### CM.3 — `contracts_macros_yaml_codegen_roundtrip`
+
+**Path**: `examples/contracts-macros/contracts_macros_yaml_codegen_roundtrip.rs`
+**Demonstrates**: generate Rust contract code from a YAML contract file (the bridge from runtime YAML validator to compile-time enforcement). Show YAML → Rust → applied attribute roundtrip with byte-identical re-generation.
+**API surface**: `aprender_contracts_macros::codegen::from_yaml(path) -> TokenStream`
+**IIUR isolation**: YAML input inline; tempdir for generated `.rs`; assertion: parse(generated) == parse(re-generated).
+**Citation**: aprender-contracts-macros crate docs (→ pin)
+
+---
+
+## Coverage matrix
+
+| Crate | Recipes | All API-stable? | All offline-friendly? | All IIUR-clean? |
+|-------|---------|-----------------|-----------------------|-----------------|
+| `aprender-mcp` | 3 (MCP-EMB.1, .2, .3) | ✅ post-M5 (FALSIFY-MCP-009 byte-parity) | ✅ in-memory I/O | ✅ tempdir + RecipeContext |
+| `aprender-tsp` | 3 (TSP.1, .2, .3) | ✅ | ✅ inline graph generation | ✅ tempdir for .apr |
+| `aprender-shell` | 3 (SH.1, .2, .3) | ✅ | ✅ synthetic history | ✅ tempdir for corpus + model |
+| `aprender-monte-carlo` | 3 (MC.1, .2, .3) | ✅ | ✅ pure RNG simulation | ✅ deterministic seed |
+| `aprender-cgp` | 3 (CGP.1, .2, .3) | ⚠️ wgpu/CUDA optional features | ✅ scalar baseline always available | ✅ tempdir for reports |
+| `aprender-contracts-macros` | 3 (CM.1, .2, .3) | ✅ proc-macros are stable surface | ✅ compile-time + pure-function tests | ✅ no I/O |
+
+**Total subcrate recipes: 18**, satisfying the ≥3-per-crate requirement with no padding.
+
+## Authoring notes
+
+1. **Citation resolution**: 4 recipes use `→ resolve` / `→ pin` placeholders. Recipe authors verify the citation against docs.rs / arXiv at recipe-authoring time. Acceptable to fall back to `Citation: aprender-<subcrate> crate v0.31.2 docs.rs reference` if no concrete academic cite exists.
+
+2. **Subcrate stability concerns**: `aprender-tsp`, `aprender-shell`, `aprender-monte-carlo` are pre-1.0 and may have API churn. Per [scope.md](scope.md) Risk Register, recipe failure on minor bumps surfaces as a cookbook test fail — that's the intended canary.
+
+3. **GPU-required recipes**: CGP.1 has GPU backends gated behind `cfg`. The CPU-only smoke (scalar backend) is the floor for CI green; full backend matrix is opt-in via local `cargo test --features cuda,wgpu`.

--- a/docs/specifications/expand-cookbooks/tickets.md
+++ b/docs/specifications/expand-cookbooks/tickets.md
@@ -1,0 +1,377 @@
+# PMAT Ticket Breakdown
+
+44 recipes decomposed into **12 PMAT tickets** (PMAT-072..083), one per category cluster. Ticket numbers are placeholders; actual numbers assigned by `pmat work add` at execution time.
+
+Each ticket is independently shippable and testable. Tickets within Tier 1 are P1 priority; sister-crate tickets are P2; perf/authoring tickets are P3.
+
+---
+
+## Cargo.toml additions (PMAT-072 prerequisite)
+
+Six new dev-dependencies required across all sister-crate tickets. Land in PMAT-072; subsequent tickets depend on this:
+
+```toml
+[dev-dependencies]
+# Sister crates (PMAT-072 expand-cookbooks)
+aprender-mcp = "0.31.2"
+aprender-tsp = "0.31.2"
+aprender-shell = "0.31.2"
+aprender-monte-carlo = "0.31.2"
+aprender-cgp = "0.31.2"
+aprender-contracts-macros = "0.31.2"
+```
+
+If any subcrate has incompatible features or unavailable on the target platform, gate behind a feature flag in apr-cookbook's `[features]` section.
+
+---
+
+## PMAT-072 — Cargo.toml + new categories scaffolding
+
+**Priority**: P1
+**Estimate**: 0.5 day
+**Depends on**: spec acceptance
+
+### Scope
+
+1. Add 6 sister-crate dev-dependencies (above).
+2. Create 6 new category directories: `examples/{code,tsp,shell,monte-carlo,cgp,contracts-macros}/`.
+3. Add empty `[[example]]` placeholders or skip — wire each example as it lands.
+4. Update `book/src/SUMMARY.md` to add 6 new top-level sections.
+5. Update `docs/specifications/components/recipe-catalog.md` to add 6 new category tables.
+
+### Definition of Done
+
+- `cargo build --lib` clean (new deps resolve)
+- `cargo tree | grep aprender-` shows 6 new entries
+- mdbook builds with 6 new (placeholder) section headers
+
+---
+
+## PMAT-073 — `apr code` agentic recipes (Tier 1, §1.2)
+
+**Priority**: P1
+**Estimate**: 3 days (most complex new surface)
+**Depends on**: PMAT-072
+
+### Scope
+
+7 recipes per [recipe-catalog.md](recipe-catalog.md) §"code/":
+- `code_mcp_client_register`
+- `code_slash_command_extension`
+- `code_hook_session_start`
+- `code_subagent_spawn`
+- `code_custom_agent_discovery`
+- `code_skill_discovery`
+- `code_worktree_isolation_permission_mode`
+
+Each ships with the IIUR doc header, citation to `apr-code-parity-v1.yaml` row + an upstream paper, `#[cfg(test)] mod tests` block.
+
+### Definition of Done
+
+- All 7 build clean
+- All 7 pass `cargo test --example <name>`
+- Each demonstrates one row from `apr-code-parity-v1.yaml` v5.1
+- Book chapters under `book/src/code/` for each recipe
+
+---
+
+## PMAT-074 — GPU/CPU oracle bisection (Tier 1, §1.1)
+
+**Priority**: P1
+**Estimate**: 2 days
+**Depends on**: PMAT-072
+
+### Scope
+
+3 recipes:
+- `cli/cli_trace_save_tensor_layer0` — capture per-stage tensor dumps in APRT byte format
+- `cli/cli_diff_values_aprt_stage` — diff captured tensors element-wise
+- `analysis/analysis_cpu_vs_gpu_parity_gate` — assert cosine ≥ threshold; below → fail closed
+
+### Definition of Done
+
+- All 3 build + test green on CPU-only (GPU-path tests `#[cfg_attr(...)] ignore`)
+- `apr-cpu-vs-gpu-output-parity-v1.yaml` v1.5.0 ACTIVE referenced in docs
+- Recipe walks the SHIP-007 layer-0 oracle bisection workflow end-to-end with a synthetic example
+
+---
+
+## PMAT-075 — `apr publish` end-to-end (Tier 1, §1.3)
+
+**Priority**: P1
+**Estimate**: 1.5 days
+**Depends on**: PMAT-072
+
+### Scope
+
+3 recipes:
+- `cli/cli_publish_manifest_full` — full validate → manifest → upload (dry-run)
+- `cli/cli_validate_manifest_live_safetensors_dtype` — FALSIFY-PM-007 SafeTensors dtype canary
+- (third recipe folded into validate-manifest-live; keep at 2 if scope tight)
+
+### Definition of Done
+
+- All recipes use `--dry-run` or tempdir destinations (offline-only per IIUR)
+- `publish-manifest-v1.yaml` v1.1.0 falsifier set referenced in docs
+- The "30.46 GiB F32 fp16-manifest bug" scenario from SHIP-TWO-001 §12.7.2 is exercised in a `#[should_panic]` test
+
+---
+
+## PMAT-076 — `apr serve anthropic` + `apr serve plan hf://` (Tier 1, §1.4 + §1.6)
+
+**Priority**: P1
+**Estimate**: 1 day
+**Depends on**: PMAT-072
+
+### Scope
+
+2 recipes:
+- `serve/serve_anthropic_messages_api_drop_in` — Claude Messages API drop-in demo
+- `serve/serve_plan_hf_dryrun_no_weights` — `apr serve plan hf://org/repo` config-only
+
+### Definition of Done
+
+- Anthropic recipe uses local mock or test fixture (not live API)
+- HF dry-run recipe stubs the HF client (no real network) per IIUR offline rule
+- Both ground against `apr-claude-proxy-v1.yaml` (DRAFT) for the Anthropic recipe
+
+---
+
+## PMAT-077 — MCP M5 transports + notifications (Tier 1, §1.5)
+
+**Priority**: P1
+**Estimate**: 1.5 days
+**Depends on**: PMAT-072
+
+### Scope
+
+4 recipes:
+- `mcp/mcp_sse_server_transport`
+- `mcp/mcp_websocket_server_transport`
+- `mcp/mcp_notification_progress_long_running`
+- `mcp/mcp_byte_parity_pmcp_dispatcher` (FALSIFY-MCP-009)
+
+### Definition of Done
+
+- All 4 use in-memory transports for testability
+- Byte-parity test asserts hand-rolled and pmcp produce identical output
+- Progress notification test verifies the notification JSON shape
+
+---
+
+## PMAT-078 — `aprender-mcp` embedded recipes (Tier 2)
+
+**Priority**: P2
+**Estimate**: 1 day
+**Depends on**: PMAT-072, PMAT-077 (shares MCP infrastructure)
+
+### Scope
+
+3 recipes per [subcrate-coverage.md](subcrate-coverage.md) §"aprender-mcp":
+- `mcp_embedded_server_minimal`
+- `mcp_embedded_register_custom_tool`
+- `mcp_embedded_byte_parity_pmcp`
+
+### Definition of Done
+
+- Recipes embed `aprender-mcp` directly (not via `apr-cli`)
+- All 3 use `Cursor`/`Vec<u8>` transports for IIUR isolation
+
+---
+
+## PMAT-079 — `aprender-tsp` recipes (Tier 2)
+
+**Priority**: P2
+**Estimate**: 1 day
+**Depends on**: PMAT-072
+
+### Scope
+
+3 recipes:
+- `tsp/tsp_personalized_route_apr`
+- `tsp/tsp_local_2opt_optimization`
+- `tsp/tsp_train_personalized_apr_model`
+
+### Definition of Done
+
+- Each demonstrates a different aprender-tsp API entry point
+- Synthetic graphs/history; no external data files
+- Round-trip determinism asserted (same seed → same route)
+
+---
+
+## PMAT-080 — `aprender-shell` recipes (Tier 2)
+
+**Priority**: P2
+**Estimate**: 1 day
+**Depends on**: PMAT-072
+
+### Scope
+
+3 recipes:
+- `shell/shell_history_to_apr_corpus`
+- `shell/shell_completion_train_local`
+- `shell/shell_completion_serve_inline`
+
+### Definition of Done
+
+- Synthetic history strings inline (no real `.zsh_history` access)
+- Trained model size asserted < 10 MB
+- Top-k completion contains expected tokens
+
+---
+
+## PMAT-081 — `aprender-monte-carlo` recipes (Tier 2)
+
+**Priority**: P2
+**Estimate**: 0.5 day (math-heavy but no external deps)
+**Depends on**: PMAT-072
+
+### Scope
+
+3 recipes:
+- `monte-carlo/mc_stock_price_simulation_gbm`
+- `monte-carlo/mc_business_revenue_forecast`
+- `monte-carlo/mc_value_at_risk_historical_vs_parametric`
+
+### Definition of Done
+
+- All deterministic via RecipeContext seed
+- Each asserts a known property (GBM mean ≈ analytical, P50 ≤ P90, |hist_VaR - param_VaR| < ε)
+
+---
+
+## PMAT-082 — `aprender-cgp` recipes (Tier 2)
+
+**Priority**: P2
+**Estimate**: 1 day (cross-backend complexity)
+**Depends on**: PMAT-072
+
+### Scope
+
+3 recipes:
+- `cgp/cgp_unified_kernel_profile_scalar_simd_wgpu_cuda`
+- `cgp/cgp_perf_regression_gate_ci`
+- `cgp/cgp_cross_backend_comparison_report`
+
+### Definition of Done
+
+- Scalar backend always tested; SIMD on x86_64; wgpu/CUDA gated
+- Regression gate test asserts threshold sensitivity (0% passes, 6% fails)
+
+---
+
+## PMAT-083 — `aprender-contracts-macros` recipes (Tier 2)
+
+**Priority**: P2
+**Estimate**: 0.5 day
+**Depends on**: PMAT-072
+
+### Scope
+
+3 recipes:
+- `contracts-macros/contracts_macros_attribute_basic`
+- `contracts-macros/contracts_macros_compile_time_precondition`
+- `contracts-macros/contracts_macros_yaml_codegen_roundtrip`
+
+### Definition of Done
+
+- All 3 use `#[contract]` attribute macro
+- One uses `compile_fail` doc-test for compile-time enforcement demo
+- Roundtrip recipe asserts YAML → Rust → YAML byte-identical
+
+---
+
+## PMAT-084 — Tier 3 perf bench recipes (lower priority)
+
+**Priority**: P3
+**Estimate**: 1 day
+**Depends on**: PMAT-072
+
+### Scope
+
+4 recipes (Tier 3):
+- `acceleration/acceleration_moe_rayon_dispatch_bench`
+- `acceleration/acceleration_mmap_per_tensor_diff_bench`
+- `bundling/bundle_streaming_q4k_large_model`
+- `conversion/conversion_gguf_legacy_quant_fallback`
+- `inference/inference_qwen3_moe_numerical_parity_smoke`
+
+### Definition of Done
+
+- Bench recipes use `criterion` or `std::time::Instant` for timing
+- Synthetic inputs sized to demonstrate the speedup without requiring real ≥4 GiB models in CI
+- Threshold assertions (e.g., MoE rayon dispatch > 1.5× speedup vs. serial baseline on multi-core)
+
+---
+
+## PMAT-085 — Tier 4 authoring patterns + extended distillation (lower priority)
+
+**Priority**: P3
+**Estimate**: 1 day
+**Depends on**: PMAT-072
+
+### Scope
+
+4 recipes:
+- `analysis/analysis_contract_algorithm_binding_pattern`
+- `analysis/analysis_pv_check_parity_authoring`
+- `analysis/analysis_json_schema_draft7_meta_validation`
+- `distillation/distill_against_contract_v1`
+
+### Definition of Done
+
+- Each authoring-pattern recipe walks the contract-author workflow with a working example
+- Distillation recipe explicitly cites and tests against `apr-cli-distill-train-v1.yaml` falsifier set
+- `pv check-parity` recipe creates a synthetic parity-matrix contract and runs the gate
+
+---
+
+## PMAT-086 — Spec bump v6.0.0 → v6.1.0 + closeout
+
+**Priority**: P3
+**Estimate**: 0.5 day
+**Depends on**: PMAT-072..085 all merged
+
+### Scope
+
+1. Bump `docs/specifications/apr-cookbook.md` Version 6.0.0 → 6.1.0
+2. Update Tech Stack diagram with the 6 new categories + sister crates
+3. Update README hero to reflect 34 categories / ~440 recipes
+4. Regenerate recipe table via `scripts/generate-recipe-table.sh --update`
+5. Tag `v6.1.0`
+
+### Definition of Done
+
+- README + spec + book reflect expanded scope
+- v6.1.0 git tag pushed
+- All 12 expand-cookbooks PMAT tickets show `completed` in roadmap
+
+---
+
+## Dependency Graph
+
+```
+PMAT-072 (scaffold) ─┬─→ PMAT-073 (apr code, P1)
+                     ├─→ PMAT-074 (GPU/CPU bisection, P1)
+                     ├─→ PMAT-075 (apr publish, P1)
+                     ├─→ PMAT-076 (apr serve anthropic + plan hf://, P1)
+                     ├─→ PMAT-077 (MCP M5, P1) ──→ PMAT-078 (aprender-mcp, P2)
+                     ├─→ PMAT-079 (aprender-tsp, P2)
+                     ├─→ PMAT-080 (aprender-shell, P2)
+                     ├─→ PMAT-081 (aprender-monte-carlo, P2)
+                     ├─→ PMAT-082 (aprender-cgp, P2)
+                     ├─→ PMAT-083 (aprender-contracts-macros, P2)
+                     ├─→ PMAT-084 (perf benches, P3)
+                     └─→ PMAT-085 (authoring + distill, P3)
+                                   ↓
+                          PMAT-086 (spec bump v6.1.0, P3)
+```
+
+PMAT-073..083 can be parallelized after PMAT-072 lands. PMAT-084..085 in parallel with the P1/P2 work; PMAT-086 closes after all merge.
+
+---
+
+## Backout Plan
+
+Each ticket merges as its own PR; revert any single PR with `git revert <merge-sha>`. The 6 new sister-crate dev-dependencies in PMAT-072 are additive — reverting just removes recipes that depend on them. No destructive operations until PMAT-086 spec bump.


### PR DESCRIPTION
## Summary

Companion to centralize-cookbooks (which shipped v6.0.0). `expand-cookbooks` plans **44 new recipes** across 6 new categories and 8 extended categories to cover the substantial new aprender surface (0.31.0..0.31.2 Unreleased) that has zero recipes today.

## Spec layout

- `docs/specifications/expand-cookbooks.md` — master (acceptance criteria, non-goals, risk register)
- `docs/specifications/expand-cookbooks/scope.md` — charter expansion (28 → 34 categories, 388 → ~440 recipes)
- `docs/specifications/expand-cookbooks/gap-inventory.md` — Tier 1-4 gaps from changelog diff
- `docs/specifications/expand-cookbooks/recipe-catalog.md` — every recipe spelled out (path + citation seed)
- `docs/specifications/expand-cookbooks/subcrate-coverage.md` — **≥3 recipes per sister crate** (the hard requirement, 18 recipes)
- `docs/specifications/expand-cookbooks/tickets.md` — PMAT-072..086, 12 tickets, dep graph, backout plan

## Headline gaps (Tier 1, 25 recipes)

- **GPU/CPU oracle bisection** (the silent-GPU-gibberish canary, `apr trace --save-tensor` + `apr diff --values` APRT + cosine parity gate): 0 recipes today
- **`apr code`** (Claude Code parity, 21-row matrix, 14 SHIPPED): 0 recipes
- **`apr publish` end-to-end** (publish-manifest-v1 + validate-manifest --live + SafeTensors header dtype): only validation half covered
- **`apr serve anthropic`** (Claude Messages API drop-in, claude-proxy contract): 0 recipes
- **MCP M5 transports** (SSE, WebSocket, notifications/cancelled, notifications/progress): 0 recipes
- **`apr serve plan hf://`** (config-only dry-run, no weights): 0 recipes
- **`apr-cli-distill-train-v1`** contract grounding: existing distill recipes don't reference the falsifier set
- **Streaming APR→Q4K for ≥4 GiB models** (ALB-093): tiny-model demo only

## Sister-crate coverage (Tier 2, hard requirement)

| Crate | v0.31.2 | Recipes today | Required |
|-------|---------|---------------|----------|
| `aprender-mcp` | ✅ | 0 | **3** |
| `aprender-tsp` | ✅ | 0 | **3** |
| `aprender-shell` | ✅ | 0 | **3** |
| `aprender-monte-carlo` | ✅ | 0 | **3** |
| `aprender-cgp` | ✅ | 0 | **3** |
| `aprender-contracts-macros` | ✅ | 0 | **3** |

Each subcrate's 3 recipes are fully specified in [subcrate-coverage.md](docs/specifications/expand-cookbooks/subcrate-coverage.md) — name, path, demonstrates, API surface, IIUR isolation strategy, citation.

## Status

`PROPOSED`. Moves to `ACTIVE` on owner approval + PMAT-073 created. Until then, no Cargo.toml changes and no examples land.

## Test plan

- [x] All 6 spec files committed
- [x] `bash scripts/check_readme_claims.sh`-style script not yet needed (spec is doc-only)
- [x] PMAT-072 ticket created and referenced in commit message

## What I'm NOT doing in this PR

- Not implementing any recipes (each cluster is its own PMAT ticket: PMAT-073..085)
- Not bumping the cookbook spec to v6.1.0 (that's PMAT-086, after all recipes land)
- Not modifying Cargo.toml (PMAT-072's job, separate PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)