### PR TITLE
feat(expand-cookbooks): PMAT-077 — apr serve anthropic + plan hf:// (2 recipes)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1818,3 +1818,12 @@ path = "examples/code/code_subagent_spawn_payload.rs"
 [[example]]
 name = "code_worktree_isolation_permission_mode"
 path = "examples/code/code_worktree_isolation_permission_mode.rs"
+# --- apr serve recipes (PMAT-077 expand-cookbooks) ---
+
+[[example]]
+name = "serve_anthropic_messages_api_drop_in"
+path = "examples/serve/serve_anthropic_messages_api_drop_in.rs"
+
+[[example]]
+name = "serve_plan_hf_dryrun_no_weights"
+path = "examples/serve/serve_plan_hf_dryrun_no_weights.rs"

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ cargo run --example 2>&1 | head -50
 <!-- Re-generate: ./scripts/generate-recipe-table.sh --update -->
 <!-- CI validates: recipe-table workflow ensures this table matches source -->
 
-**399 recipes** | Build: [![CI](https://github.com/paiml/apr-cookbook/actions/workflows/ci.yml/badge.svg)](https://github.com/paiml/apr-cookbook/actions/workflows/ci.yml)
+**401 recipes** | Build: [![CI](https://github.com/paiml/apr-cookbook/actions/workflows/ci.yml/badge.svg)](https://github.com/paiml/apr-cookbook/actions/workflows/ci.yml)
 
 <details>
 <summary>Full recipe table (click to expand)</summary>
@@ -482,60 +482,62 @@ cargo run --example 2>&1 | head -50
 | 343 | `model_canary_deploy` | serve | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
 | 344 | `model_rate_limiter` | serve | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
 | 345 | `model_selection_router` | serve | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
-| 346 | `serve_grpc_stream` | serve | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
-| 347 | `serve_rate_limited` | serve | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
-| 348 | `serverless_cold_start_optimization` | serverless | ![serverless](https://img.shields.io/badge/-serverless-yellow) | ✅ |
-| 349 | `serverless_container_image` | serverless | ![serverless](https://img.shields.io/badge/-serverless-yellow) | ✅ |
-| 350 | `serverless_edge_function` | serverless | ![serverless](https://img.shields.io/badge/-serverless-yellow) | ✅ |
-| 351 | `serverless_lambda_inference` | serverless | ![serverless](https://img.shields.io/badge/-serverless-yellow) | ✅ |
-| 352 | `serverless_model_warmup` | serverless | ![serverless](https://img.shields.io/badge/-serverless-yellow) | ✅ |
-| 353 | `shell_corpus_from_string` | shell | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
-| 354 | `shell_history_parse_zsh` | shell | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
-| 355 | `shell_trie_prefix_completion` | shell | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
-| 356 | `simd_auto_vectorization` | simd | ![x86_64](https://img.shields.io/badge/-x86__64-blue) | ✅ |
-| 357 | `simd_avx_vnni_int8_inference` | simd | ![x86_64](https://img.shields.io/badge/-x86__64-blue) ![aarch64](https://img.shields.io/badge/-aarch64-blue) | ✅ |
-| 358 | `simd_matrix_ops` | simd | ![x86_64](https://img.shields.io/badge/-x86__64-blue) ![aarch64](https://img.shields.io/badge/-aarch64-blue) | ✅ |
-| 359 | `simd_quantized_operations` | simd | ![x86_64](https://img.shields.io/badge/-x86__64-blue) | ✅ |
-| 360 | `simd_vectorized_inference` | simd | ![x86_64](https://img.shields.io/badge/-x86__64-blue) | ✅ |
-| 361 | `trueno_simd_ops` | simd | ![x86_64](https://img.shields.io/badge/-x86__64-blue) ![aarch64](https://img.shields.io/badge/-aarch64-blue) | ✅ |
-| 362 | `speech_diarization` | speech | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
-| 363 | `speech_multilingual` | speech | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
-| 364 | `speech_vad` | speech | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
-| 365 | `whisper_streaming` | speech | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
-| 366 | `whisper_transcribe` | speech | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
-| 367 | `autograd_backprop_viz` | training | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
-| 368 | `autograd_custom_ops` | training | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
-| 369 | `autograd_gradient_clipping` | training | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
-| 370 | `checkpoint_resume` | training | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
-| 371 | `continuous_train_curriculum` | training | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
-| 372 | `continuous_train_federated_simulation` | training | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
-| 373 | `continuous_train_incremental` | training | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
-| 374 | `continuous_train_online_learning` | training | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
-| 375 | `data_preprocessing` | training | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
-| 376 | `data_sharded_shuffle` | training | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
-| 377 | `data_streaming_tokens` | training | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
-| 378 | `entrenar_autograd_training` | training | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
-| 379 | `entrenar_eval_metrics` | training | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
-| 380 | `few_shot_finetune` | training | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
-| 381 | `gradient_accumulation` | training | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
-| 382 | `hyperparameter_sweep` | training | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
-| 383 | `learning_rate_schedule` | training | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
-| 384 | `mixed_precision_training` | training | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
-| 385 | `pretrain_checkpoint_resume` | training | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
-| 386 | `pretrain_nan_guard` | training | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
-| 387 | `pretrain_synthetic_decreasing` | training | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
-| 388 | `train_distributed_sim` | training | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
-| 389 | `train_grad_accum` | training | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
-| 390 | `tsp_compare_tabu_vs_genetic` | tsp | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
-| 391 | `tsp_distance_matrix_explicit` | tsp | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
-| 392 | `tsp_solve_with_tabu` | tsp | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
-| 393 | `load_visualization` | visualization | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
-| 394 | `wasm_browser_inference` | wasm | ![wasm](https://img.shields.io/badge/-wasm-purple) | ✅ |
-| 395 | `wasm_model_loader` | wasm | ![wasm](https://img.shields.io/badge/-wasm-purple) | ✅ |
-| 396 | `wasm_progressive_loading` | wasm | ![wasm](https://img.shields.io/badge/-wasm-purple) | ✅ |
-| 397 | `wasm_streaming_compilation` | wasm | ![wasm](https://img.shields.io/badge/-wasm-purple) | ✅ |
-| 398 | `wasm_web_worker` | wasm | ![wasm](https://img.shields.io/badge/-wasm-purple) | ✅ |
-| 399 | `wasm_webgpu_acceleration` | wasm | ![wgpu](https://img.shields.io/badge/-wgpu-green) ![wasm](https://img.shields.io/badge/-wasm-purple) | ✅ |
+| 346 | `serve_anthropic_messages_api_drop_in` | serve | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
+| 347 | `serve_grpc_stream` | serve | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
+| 348 | `serve_plan_hf_dryrun_no_weights` | serve | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
+| 349 | `serve_rate_limited` | serve | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
+| 350 | `serverless_cold_start_optimization` | serverless | ![serverless](https://img.shields.io/badge/-serverless-yellow) | ✅ |
+| 351 | `serverless_container_image` | serverless | ![serverless](https://img.shields.io/badge/-serverless-yellow) | ✅ |
+| 352 | `serverless_edge_function` | serverless | ![serverless](https://img.shields.io/badge/-serverless-yellow) | ✅ |
+| 353 | `serverless_lambda_inference` | serverless | ![serverless](https://img.shields.io/badge/-serverless-yellow) | ✅ |
+| 354 | `serverless_model_warmup` | serverless | ![serverless](https://img.shields.io/badge/-serverless-yellow) | ✅ |
+| 355 | `shell_corpus_from_string` | shell | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
+| 356 | `shell_history_parse_zsh` | shell | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
+| 357 | `shell_trie_prefix_completion` | shell | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
+| 358 | `simd_auto_vectorization` | simd | ![x86_64](https://img.shields.io/badge/-x86__64-blue) | ✅ |
+| 359 | `simd_avx_vnni_int8_inference` | simd | ![x86_64](https://img.shields.io/badge/-x86__64-blue) ![aarch64](https://img.shields.io/badge/-aarch64-blue) | ✅ |
+| 360 | `simd_matrix_ops` | simd | ![x86_64](https://img.shields.io/badge/-x86__64-blue) ![aarch64](https://img.shields.io/badge/-aarch64-blue) | ✅ |
+| 361 | `simd_quantized_operations` | simd | ![x86_64](https://img.shields.io/badge/-x86__64-blue) | ✅ |
+| 362 | `simd_vectorized_inference` | simd | ![x86_64](https://img.shields.io/badge/-x86__64-blue) | ✅ |
+| 363 | `trueno_simd_ops` | simd | ![x86_64](https://img.shields.io/badge/-x86__64-blue) ![aarch64](https://img.shields.io/badge/-aarch64-blue) | ✅ |
+| 364 | `speech_diarization` | speech | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
+| 365 | `speech_multilingual` | speech | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
+| 366 | `speech_vad` | speech | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
+| 367 | `whisper_streaming` | speech | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
+| 368 | `whisper_transcribe` | speech | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
+| 369 | `autograd_backprop_viz` | training | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
+| 370 | `autograd_custom_ops` | training | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
+| 371 | `autograd_gradient_clipping` | training | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
+| 372 | `checkpoint_resume` | training | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
+| 373 | `continuous_train_curriculum` | training | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
+| 374 | `continuous_train_federated_simulation` | training | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
+| 375 | `continuous_train_incremental` | training | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
+| 376 | `continuous_train_online_learning` | training | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
+| 377 | `data_preprocessing` | training | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
+| 378 | `data_sharded_shuffle` | training | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
+| 379 | `data_streaming_tokens` | training | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
+| 380 | `entrenar_autograd_training` | training | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
+| 381 | `entrenar_eval_metrics` | training | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
+| 382 | `few_shot_finetune` | training | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
+| 383 | `gradient_accumulation` | training | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
+| 384 | `hyperparameter_sweep` | training | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
+| 385 | `learning_rate_schedule` | training | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
+| 386 | `mixed_precision_training` | training | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
+| 387 | `pretrain_checkpoint_resume` | training | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
+| 388 | `pretrain_nan_guard` | training | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
+| 389 | `pretrain_synthetic_decreasing` | training | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
+| 390 | `train_distributed_sim` | training | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
+| 391 | `train_grad_accum` | training | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
+| 392 | `tsp_compare_tabu_vs_genetic` | tsp | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
+| 393 | `tsp_distance_matrix_explicit` | tsp | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
+| 394 | `tsp_solve_with_tabu` | tsp | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
+| 395 | `load_visualization` | visualization | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
+| 396 | `wasm_browser_inference` | wasm | ![wasm](https://img.shields.io/badge/-wasm-purple) | ✅ |
+| 397 | `wasm_model_loader` | wasm | ![wasm](https://img.shields.io/badge/-wasm-purple) | ✅ |
+| 398 | `wasm_progressive_loading` | wasm | ![wasm](https://img.shields.io/badge/-wasm-purple) | ✅ |
+| 399 | `wasm_streaming_compilation` | wasm | ![wasm](https://img.shields.io/badge/-wasm-purple) | ✅ |
+| 400 | `wasm_web_worker` | wasm | ![wasm](https://img.shields.io/badge/-wasm-purple) | ✅ |
+| 401 | `wasm_webgpu_acceleration` | wasm | ![wgpu](https://img.shields.io/badge/-wgpu-green) ![wasm](https://img.shields.io/badge/-wasm-purple) | ✅ |
 
 </details>
 <!-- RECIPE-TABLE-END -->

--- a/examples/serve/serve_anthropic_messages_api_drop_in.rs
+++ b/examples/serve/serve_anthropic_messages_api_drop_in.rs
@@ -1,0 +1,165 @@
+//! # apr serve anthropic — Claude Messages API Drop-In
+//!
+//! Demonstrates the request/response shape of `apr serve anthropic` — the
+//! Claude Messages-API-compatible serving mode that lets you drop your
+//! `ANTHROPIC_API_KEY=foo` and have a sovereign apr backend answer instead.
+//! The serve mode is in aprender's Unreleased section behind
+//! `apr-claude-proxy-v1.yaml` (DRAFT).
+//!
+//! Recipe builds a sample Messages-API request envelope, validates its
+//! schema, then constructs the canonical SSE-streaming response sequence
+//! (`message_start` → `content_block_delta` × N → `message_stop`) that
+//! the proxy must emit per FALSIFY-CLAUDE-PROXY-002 (SSE event sequence).
+//!
+//! Demonstrates the **SRV+.1** recipe per
+//! `docs/specifications/expand-cookbooks/recipe-catalog.md`.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml
+//! Citation: Anthropic (2024). Messages API Reference. https://docs.anthropic.com/en/api/messages
+//!
+//! Run with: cargo run --example serve_anthropic_messages_api_drop_in
+//!
+//! Added by PMAT-077 (expand-cookbooks: apr serve anthropic + plan hf://).
+
+use apr_cookbook::recipe::RecipeContext;
+use apr_cookbook::Result;
+use serde_json::{json, Value};
+
+/// Validate a Claude Messages-API request envelope per the public schema.
+/// Returns Ok with model + message count on success.
+fn validate_messages_request(req: &Value) -> Result<(String, usize)> {
+    let model = req["model"].as_str().ok_or_else(|| {
+        apr_cookbook::CookbookError::Validation("missing required `model` (string)".into())
+    })?;
+    let max_tokens = req["max_tokens"].as_u64().ok_or_else(|| {
+        apr_cookbook::CookbookError::Validation(
+            "missing required `max_tokens` (positive integer)".into(),
+        )
+    })?;
+    if max_tokens == 0 {
+        return Err(apr_cookbook::CookbookError::Validation(
+            "max_tokens must be > 0".into(),
+        ));
+    }
+    let messages = req["messages"].as_array().ok_or_else(|| {
+        apr_cookbook::CookbookError::Validation("missing required `messages` (array)".into())
+    })?;
+    if messages.is_empty() {
+        return Err(apr_cookbook::CookbookError::Validation(
+            "messages array must be non-empty".into(),
+        ));
+    }
+    for (i, m) in messages.iter().enumerate() {
+        let role = m["role"].as_str().ok_or_else(|| {
+            apr_cookbook::CookbookError::Validation(format!(
+                "messages[{i}].role missing or not a string"
+            ))
+        })?;
+        if !matches!(role, "user" | "assistant") {
+            return Err(apr_cookbook::CookbookError::Validation(format!(
+                "messages[{i}].role must be \"user\" or \"assistant\", got {role:?}"
+            )));
+        }
+        if m["content"].is_null() {
+            return Err(apr_cookbook::CookbookError::Validation(format!(
+                "messages[{i}].content missing"
+            )));
+        }
+    }
+    Ok((model.to_string(), messages.len()))
+}
+
+/// Construct the canonical SSE event sequence that `apr serve anthropic`
+/// emits for a streaming response. Per FALSIFY-CLAUDE-PROXY-002 the sequence
+/// must start with `message_start`, contain N `content_block_delta` events,
+/// and end with `message_stop`. We build the events as named JSON values
+/// (in real wire-format each is prefixed with `event: <name>\ndata: <json>`).
+fn build_sse_event_sequence(text_chunks: &[&str]) -> Vec<(String, Value)> {
+    let mut events = Vec::with_capacity(text_chunks.len() + 2);
+    events.push((
+        "message_start".to_string(),
+        json!({"type": "message_start", "message": {"id": "msg_demo", "role": "assistant"}}),
+    ));
+    for (i, chunk) in text_chunks.iter().enumerate() {
+        events.push((
+            "content_block_delta".to_string(),
+            json!({
+                "type": "content_block_delta",
+                "index": i,
+                "delta": {"type": "text_delta", "text": chunk}
+            }),
+        ));
+    }
+    events.push(("message_stop".to_string(), json!({"type": "message_stop"})));
+    events
+}
+
+fn main() -> Result<()> {
+    let _ctx = RecipeContext::new("serve_anthropic_messages_api_drop_in")?;
+
+    let request = json!({
+        "model": "claude-opus-4-7",
+        "max_tokens": 1024,
+        "messages": [
+            {"role": "user", "content": "Summarize the IIUR principle in one sentence."}
+        ]
+    });
+    let (model, n_messages) = validate_messages_request(&request)?;
+    println!("validated request: model={model} messages={n_messages}");
+
+    let chunks = [
+        "IIUR ",
+        "means ",
+        "Isolated, ",
+        "Idempotent, ",
+        "Useful, ",
+        "Reproducible.",
+    ];
+    let events = build_sse_event_sequence(&chunks);
+    println!("emitted {} SSE events:", events.len());
+    for (name, _) in &events {
+        println!("  event: {name}");
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn drop_in_runs() {
+        main().expect("recipe execution failed");
+    }
+
+    #[test]
+    fn missing_model_rejected() {
+        let bad = json!({"max_tokens": 100, "messages": [{"role": "user", "content": "hi"}]});
+        assert!(validate_messages_request(&bad).is_err());
+    }
+
+    #[test]
+    fn zero_max_tokens_rejected() {
+        let bad =
+            json!({"model": "x", "max_tokens": 0, "messages": [{"role": "user", "content": "hi"}]});
+        assert!(validate_messages_request(&bad).is_err());
+    }
+
+    #[test]
+    fn invalid_role_rejected() {
+        let bad = json!({"model": "x", "max_tokens": 100, "messages": [{"role": "system", "content": "hi"}]});
+        assert!(validate_messages_request(&bad).is_err());
+    }
+
+    #[test]
+    fn sse_sequence_brackets_with_start_stop() {
+        let events = build_sse_event_sequence(&["a", "b"]);
+        assert_eq!(
+            events.first().map(|(n, _)| n.as_str()),
+            Some("message_start")
+        );
+        assert_eq!(events.last().map(|(n, _)| n.as_str()), Some("message_stop"));
+        // 1 start + 2 deltas + 1 stop = 4 events
+        assert_eq!(events.len(), 4);
+    }
+}

--- a/examples/serve/serve_plan_hf_dryrun_no_weights.rs
+++ b/examples/serve/serve_plan_hf_dryrun_no_weights.rs
@@ -1,0 +1,141 @@
+//! # apr serve plan — HuggingFace Dry-Run (no weight download)
+//!
+//! `apr serve plan hf://org/repo` reads ONLY the ~2 KB `config.json` from a
+//! HuggingFace repo (no weight tensors), validates the model architecture
+//! (n_layers, hidden_size, vocab_size, etc.), and prints a deployment plan
+//! without ever downloading the GB-scale `.safetensors` shards. Useful in CI
+//! to validate a model can be served before paying the bandwidth.
+//!
+//! This recipe demonstrates the `config.json` schema validator that the
+//! `apr serve plan` flow uses, with a synthetic config inline so the recipe
+//! is offline-only per IIUR.
+//!
+//! Demonstrates the **SRV+.2** recipe per
+//! `docs/specifications/expand-cookbooks/recipe-catalog.md`.
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml
+//! Citation: HuggingFace (2024). Hub Model Card + config.json conventions. https://huggingface.co/docs/hub/model-cards
+//!
+//! Run with: cargo run --example serve_plan_hf_dryrun_no_weights
+//!
+//! Added by PMAT-077 (expand-cookbooks: apr serve anthropic + plan hf://).
+
+use apr_cookbook::recipe::RecipeContext;
+use apr_cookbook::Result;
+use serde_json::Value;
+
+const SAMPLE_QWEN_CONFIG: &str = r#"{
+  "model_type": "qwen2",
+  "architectures": ["Qwen2ForCausalLM"],
+  "vocab_size": 151936,
+  "hidden_size": 3584,
+  "num_hidden_layers": 28,
+  "num_attention_heads": 28,
+  "num_key_value_heads": 4,
+  "max_position_embeddings": 32768,
+  "rope_theta": 1000000.0,
+  "torch_dtype": "bfloat16"
+}"#;
+
+/// Minimal deployment plan extracted from a HuggingFace `config.json`.
+#[derive(Debug)]
+struct DeploymentPlan {
+    model_type: String,
+    architecture: String,
+    n_layers: u64,
+    hidden_size: u64,
+    vocab_size: u64,
+    estimated_params_b: f64,
+}
+
+fn build_plan_from_config(json: &str) -> Result<DeploymentPlan> {
+    let cfg: Value = serde_json::from_str(json).map_err(|e| {
+        apr_cookbook::CookbookError::Validation(format!("config.json parse error: {e}"))
+    })?;
+    let model_type = cfg["model_type"]
+        .as_str()
+        .ok_or_else(|| {
+            apr_cookbook::CookbookError::Validation("model_type missing from config.json".into())
+        })?
+        .to_string();
+    let architecture = cfg["architectures"][0]
+        .as_str()
+        .ok_or_else(|| {
+            apr_cookbook::CookbookError::Validation(
+                "architectures[0] missing from config.json".into(),
+            )
+        })?
+        .to_string();
+    let n_layers = cfg["num_hidden_layers"].as_u64().ok_or_else(|| {
+        apr_cookbook::CookbookError::Validation("num_hidden_layers missing".into())
+    })?;
+    let hidden_size = cfg["hidden_size"]
+        .as_u64()
+        .ok_or_else(|| apr_cookbook::CookbookError::Validation("hidden_size missing".into()))?;
+    let vocab_size = cfg["vocab_size"]
+        .as_u64()
+        .ok_or_else(|| apr_cookbook::CookbookError::Validation("vocab_size missing".into()))?;
+    // Rough order-of-magnitude param estimate for a transformer:
+    // params ~= n_layers * (12 * hidden^2 + 13*hidden) + 2 * vocab * hidden
+    let h = hidden_size as f64;
+    let l = n_layers as f64;
+    let v = vocab_size as f64;
+    let params = l * (12.0 * h * h + 13.0 * h) + 2.0 * v * h;
+    let estimated_params_b = params / 1e9;
+    Ok(DeploymentPlan {
+        model_type,
+        architecture,
+        n_layers,
+        hidden_size,
+        vocab_size,
+        estimated_params_b,
+    })
+}
+
+fn main() -> Result<()> {
+    let _ctx = RecipeContext::new("serve_plan_hf_dryrun_no_weights")?;
+    let plan = build_plan_from_config(SAMPLE_QWEN_CONFIG)?;
+    println!("deployment plan from synthetic Qwen-style config.json (no weights downloaded):");
+    println!("  model_type: {}", plan.model_type);
+    println!("  architecture: {}", plan.architecture);
+    println!("  layers: {}", plan.n_layers);
+    println!("  hidden_size: {}", plan.hidden_size);
+    println!("  vocab_size: {}", plan.vocab_size);
+    println!("  estimated params: ~{:.2}B", plan.estimated_params_b);
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn plan_runs() {
+        main().expect("recipe execution failed");
+    }
+
+    #[test]
+    fn synthetic_config_yields_qwen2_architecture() {
+        let plan = build_plan_from_config(SAMPLE_QWEN_CONFIG).unwrap();
+        assert_eq!(plan.model_type, "qwen2");
+        assert_eq!(plan.architecture, "Qwen2ForCausalLM");
+        assert_eq!(plan.n_layers, 28);
+    }
+
+    #[test]
+    fn missing_required_field_rejected() {
+        let bad = r#"{"model_type": "x", "architectures": ["X"]}"#;
+        assert!(build_plan_from_config(bad).is_err());
+    }
+
+    #[test]
+    fn estimated_params_in_billions_for_7b_class() {
+        // 28 layers × 3584 hidden × 151936 vocab ≈ 7B params order of magnitude
+        let plan = build_plan_from_config(SAMPLE_QWEN_CONFIG).unwrap();
+        assert!(
+            plan.estimated_params_b > 4.0 && plan.estimated_params_b < 12.0,
+            "expected ~7B param estimate, got {:.2}B",
+            plan.estimated_params_b
+        );
+    }
+}


### PR DESCRIPTION
Tier-1 high-value cluster: covers the two new `apr serve` modes from aprender 0.31.0 Unreleased.

## What lands

| Recipe | Demonstrates | Tests |
|--------|--------------|-------|
| `serve_anthropic_messages_api_drop_in` | Claude Messages-API request validator + canonical SSE event sequence (`message_start` → `content_block_delta` × N → `message_stop`) per `apr-claude-proxy-v1.yaml` FALSIFY-CLAUDE-PROXY-002 | 5 |
| `serve_plan_hf_dryrun_no_weights` | `config.json` parser → DeploymentPlan with model_type/architecture/n_layers/hidden_size/vocab_size/estimated_params; verifies the ~7B param estimate for synthetic Qwen2-style config | 4 |
| **Total** | | **9** |

Both offline-only per IIUR (no real Anthropic API call, no real HF Hub fetch).

## Test plan

- [x] Both build + test green
- [x] `cargo fmt --all -- --check` clean
- [x] Pre-push gates green
- [x] README recipe table regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)