### PR TITLE
feat(expand-cookbooks): PMAT-087 — bump cookbook spec to v6.1.0 + close expand-cookbooks initiative

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,11 @@
 </p>
 
 <p align="center">
-  <em>v6.0.0 (2026-05-05) consolidates sovereign-ai-cookbook, alimentar examples, and presentar examples into this repository per <a href="docs/specifications/centralize-cookbooks.md">centralize-cookbooks</a>. Source repositories archived 2026-05-05 (PMAT-070): <s><a href="https://github.com/paiml/sovereign-ai-cookbook">sovereign-ai-cookbook</a></s>, <s><a href="https://github.com/paiml/alimentar">alimentar</a></s>, <s><a href="https://github.com/paiml/presentar">presentar</a></s>. The alimentar and presentar Rust crates remain published on crates.io as <code>aprender-data</code> and <code>presentar</code> respectively.</em>
+  <em>v6.1.0 (2026-05-05) closes the <a href="docs/specifications/expand-cookbooks.md">expand-cookbooks</a> sprint: 44 new recipes covering Claude Code parity (<code>apr code</code>), GPU/CPU oracle bisection, MCP M5 transports, Anthropic Messages API drop-in, end-to-end publish, and 6 sister crates (<code>aprender-{mcp,tsp,shell,monte-carlo,cgp,contracts-macros}</code>). 420 recipes across 34 categories.</em>
+</p>
+
+<p align="center">
+  <em>v6.0.0 (2026-05-05) consolidated sovereign-ai-cookbook, alimentar examples, and presentar examples into this repository per <a href="docs/specifications/centralize-cookbooks.md">centralize-cookbooks</a>. Source repositories archived 2026-05-05 (PMAT-070): <s><a href="https://github.com/paiml/sovereign-ai-cookbook">sovereign-ai-cookbook</a></s>, <s><a href="https://github.com/paiml/alimentar">alimentar</a></s>, <s><a href="https://github.com/paiml/presentar">presentar</a></s>. The alimentar and presentar Rust crates remain published on crates.io as <code>aprender-data</code> and <code>presentar</code> respectively.</em>
 </p>
 
 <p align="center">

--- a/docs/specifications/apr-cookbook.md
+++ b/docs/specifications/apr-cookbook.md
@@ -1,11 +1,13 @@
 # APR Cookbook Specification
 
-**Version**: 6.0.0
+**Version**: 6.1.0
 **Status**: ACTIVE
 **MSRV**: 1.89
 **Date**: 2026-05-05
 **Repository**: [github.com/paiml/apr-cookbook](https://github.com/paiml/apr-cookbook)
 **Sovereign Stack**: APR-MONO v0.31.2 ([github.com/paiml/aprender](https://github.com/paiml/aprender))
+
+**v6.1.0 (2026-05-05)**: Closes the **expand-cookbooks initiative** (spec: [`expand-cookbooks.md`](expand-cookbooks.md)). Adds **44 recipes** across 6 new categories (`code/`, `tsp/`, `shell/`, `monte-carlo/`, `cgp/`, `contracts-macros/`) and 8 extended categories (`cli/`, `serve/`, `mcp/`, `analysis/`, `acceleration/`, `bundling/`, `conversion/`, `distillation/`). Closes the gap between the cookbook and aprender 0.31.0..0.31.2 (Unreleased): Claude Code parity (`apr code`), GPU/CPU oracle bisection (the silent-GPU-gibberish canary), apr publish end-to-end, apr serve anthropic (Claude Messages API drop-in), MCP M5 transports (SSE/WebSocket/notifications), and the 6 published sister crates (`aprender-{mcp,tsp,shell,monte-carlo,cgp,contracts-macros}` v0.31.2) each with ≥3 recipes. Cookbook now at 420 recipes across 34 categories.
 
 **v5.1.0 (2026-05-05)**: Add **SHIP-TWO-001 fine-tune-from-init workflow** cross-reference (new §"SHIP-TWO-001 Workflow" section below). The aprender §50.4 cascade landed `apr pretrain --init <PATH>.apr` end-to-end on 2026-05-05 (PRs #1471-#1494, post-INTEGRATION-COMPLETE per aprender SPEC-SHIP-TWO-001 §53). Companion recipes for fine-tuning from public Qwen2.5-Coder-0.5B-Instruct via `apr tokenize import-hf` + `apr tokenize encode-corpus` + `apr pretrain --init` are tracked here as the operator-facing cookbook surface for the SHIP-TWO-001 spec.
 


### PR DESCRIPTION
Closes the **expand-cookbooks** initiative. apr-cookbook is now at **v6.1.0** with **420 recipes across 34 categories**.

## What changed

- `docs/specifications/apr-cookbook.md`: Version 6.0.0 → **6.1.0**; new v6.1.0 paragraph summarizing the expand-cookbooks deliverables
- `README.md`: new v6.1.0 hero paragraph above the v6.0.0 paragraph

## expand-cookbooks summary (PMAT-073..087)

| Ticket | Recipes | Tests | Merged |
|--------|---------|-------|--------|
| PMAT-073 + 079..084 (scaffold + 6 sister crates) | 18 | 54 | #257 |
| PMAT-074 (apr code) | 7 | 28 | #258 |
| PMAT-077 (apr serve) | 2 | 9 | #259 |
| PMAT-075 (GPU/CPU bisection) | 3 | 13 | #260 |
| PMAT-076 (apr publish) | 3 | 14 | #261 |
| PMAT-078 (MCP M5) | 4 | 17 | #262 |
| PMAT-085+086 (Tier 3+4) | 9 | 32 | #263 |
| **Total** | **44** | **167** | |

## Test plan

- [x] All 7 expand-cookbooks PRs merged to main
- [x] `cargo build --examples` clean on main
- [x] Recipe count: 374 → 420
- [x] Spec + README hero updated to reflect v6.1.0

## What's next (post-merge)

After this lands, tag `v6.1.0` on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)