### PR TITLE
feat(non-cli): PMAT-123 — 9 speech/wasm/simd recipes (closes speech F-invariant gap)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3203,3 +3203,41 @@ path = "examples/cli/cli_tui_resize_event_throttle.rs"
 [[example]]
 name = "cli_tui_pager_buffer_planner"
 path = "examples/cli/cli_tui_pager_buffer_planner.rs"
+
+# --- speech / wasm / simd extension (PMAT-123 expand-cookbooks followup) ---
+
+[[example]]
+name = "speech_audio_format_validator"
+path = "examples/speech/speech_audio_format_validator.rs"
+
+[[example]]
+name = "speech_vad_threshold_classifier"
+path = "examples/speech/speech_vad_threshold_classifier.rs"
+
+[[example]]
+name = "speech_chunk_overlap_planner"
+path = "examples/speech/speech_chunk_overlap_planner.rs"
+
+[[example]]
+name = "wasm_memory_growth_policy"
+path = "examples/wasm/wasm_memory_growth_policy.rs"
+
+[[example]]
+name = "wasm_capability_check"
+path = "examples/wasm/wasm_capability_check.rs"
+
+[[example]]
+name = "wasm_module_cache_strategy"
+path = "examples/wasm/wasm_module_cache_strategy.rs"
+
+[[example]]
+name = "simd_alignment_validator"
+path = "examples/simd/simd_alignment_validator.rs"
+
+[[example]]
+name = "simd_unroll_factor_picker"
+path = "examples/simd/simd_unroll_factor_picker.rs"
+
+[[example]]
+name = "simd_horizontal_reduce_dispatcher"
+path = "examples/simd/simd_horizontal_reduce_dispatcher.rs"

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ cargo run --example 2>&1 | head -50
 <!-- Re-generate: ./scripts/generate-recipe-table.sh --update -->
 <!-- CI validates: recipe-table workflow ensures this table matches source -->
 
-**726 recipes** | Build: [![CI](https://github.com/paiml/apr-cookbook/actions/workflows/ci.yml/badge.svg)](https://github.com/paiml/apr-cookbook/actions/workflows/ci.yml)
+**735 recipes** | Build: [![CI](https://github.com/paiml/apr-cookbook/actions/workflows/ci.yml/badge.svg)](https://github.com/paiml/apr-cookbook/actions/workflows/ci.yml)
 
 <details>
 <summary>Full recipe table (click to expand)</summary>
@@ -823,50 +823,59 @@ cargo run --example 2>&1 | head -50
 | 680 | `shell_corpus_from_string` | shell | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
 | 681 | `shell_history_parse_zsh` | shell | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
 | 682 | `shell_trie_prefix_completion` | shell | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
-| 683 | `simd_auto_vectorization` | simd | ![x86_64](https://img.shields.io/badge/-x86__64-blue) | ✅ |
-| 684 | `simd_avx_vnni_int8_inference` | simd | ![x86_64](https://img.shields.io/badge/-x86__64-blue) ![aarch64](https://img.shields.io/badge/-aarch64-blue) | ✅ |
-| 685 | `simd_matrix_ops` | simd | ![x86_64](https://img.shields.io/badge/-x86__64-blue) ![aarch64](https://img.shields.io/badge/-aarch64-blue) | ✅ |
-| 686 | `simd_quantized_operations` | simd | ![x86_64](https://img.shields.io/badge/-x86__64-blue) | ✅ |
-| 687 | `simd_vectorized_inference` | simd | ![x86_64](https://img.shields.io/badge/-x86__64-blue) | ✅ |
-| 688 | `trueno_simd_ops` | simd | ![x86_64](https://img.shields.io/badge/-x86__64-blue) ![aarch64](https://img.shields.io/badge/-aarch64-blue) | ✅ |
-| 689 | `speech_diarization` | speech | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
-| 690 | `speech_multilingual` | speech | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
-| 691 | `speech_vad` | speech | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
-| 692 | `whisper_streaming` | speech | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
-| 693 | `whisper_transcribe` | speech | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
-| 694 | `autograd_backprop_viz` | training | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
-| 695 | `autograd_custom_ops` | training | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
-| 696 | `autograd_gradient_clipping` | training | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
-| 697 | `checkpoint_resume` | training | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
-| 698 | `continuous_train_curriculum` | training | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
-| 699 | `continuous_train_federated_simulation` | training | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
-| 700 | `continuous_train_incremental` | training | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
-| 701 | `continuous_train_online_learning` | training | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
-| 702 | `data_preprocessing` | training | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
-| 703 | `data_sharded_shuffle` | training | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
-| 704 | `data_streaming_tokens` | training | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
-| 705 | `entrenar_autograd_training` | training | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
-| 706 | `entrenar_eval_metrics` | training | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
-| 707 | `few_shot_finetune` | training | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
-| 708 | `gradient_accumulation` | training | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
-| 709 | `hyperparameter_sweep` | training | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
-| 710 | `learning_rate_schedule` | training | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
-| 711 | `mixed_precision_training` | training | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
-| 712 | `pretrain_checkpoint_resume` | training | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
-| 713 | `pretrain_nan_guard` | training | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
-| 714 | `pretrain_synthetic_decreasing` | training | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
-| 715 | `train_distributed_sim` | training | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
-| 716 | `train_grad_accum` | training | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
-| 717 | `tsp_compare_tabu_vs_genetic` | tsp | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
-| 718 | `tsp_distance_matrix_explicit` | tsp | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
-| 719 | `tsp_solve_with_tabu` | tsp | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
-| 720 | `load_visualization` | visualization | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
-| 721 | `wasm_browser_inference` | wasm | ![wasm](https://img.shields.io/badge/-wasm-purple) | ✅ |
-| 722 | `wasm_model_loader` | wasm | ![wasm](https://img.shields.io/badge/-wasm-purple) | ✅ |
-| 723 | `wasm_progressive_loading` | wasm | ![wasm](https://img.shields.io/badge/-wasm-purple) | ✅ |
-| 724 | `wasm_streaming_compilation` | wasm | ![wasm](https://img.shields.io/badge/-wasm-purple) | ✅ |
-| 725 | `wasm_web_worker` | wasm | ![wasm](https://img.shields.io/badge/-wasm-purple) | ✅ |
-| 726 | `wasm_webgpu_acceleration` | wasm | ![wgpu](https://img.shields.io/badge/-wgpu-green) ![wasm](https://img.shields.io/badge/-wasm-purple) | ✅ |
+| 683 | `simd_alignment_validator` | simd | ![x86_64](https://img.shields.io/badge/-x86__64-blue) ![aarch64](https://img.shields.io/badge/-aarch64-blue) | ✅ |
+| 684 | `simd_auto_vectorization` | simd | ![x86_64](https://img.shields.io/badge/-x86__64-blue) | ✅ |
+| 685 | `simd_avx_vnni_int8_inference` | simd | ![x86_64](https://img.shields.io/badge/-x86__64-blue) ![aarch64](https://img.shields.io/badge/-aarch64-blue) | ✅ |
+| 686 | `simd_horizontal_reduce_dispatcher` | simd | ![x86_64](https://img.shields.io/badge/-x86__64-blue) | ✅ |
+| 687 | `simd_matrix_ops` | simd | ![x86_64](https://img.shields.io/badge/-x86__64-blue) ![aarch64](https://img.shields.io/badge/-aarch64-blue) | ✅ |
+| 688 | `simd_quantized_operations` | simd | ![x86_64](https://img.shields.io/badge/-x86__64-blue) | ✅ |
+| 689 | `simd_unroll_factor_picker` | simd | ![x86_64](https://img.shields.io/badge/-x86__64-blue) | ✅ |
+| 690 | `simd_vectorized_inference` | simd | ![x86_64](https://img.shields.io/badge/-x86__64-blue) | ✅ |
+| 691 | `trueno_simd_ops` | simd | ![x86_64](https://img.shields.io/badge/-x86__64-blue) ![aarch64](https://img.shields.io/badge/-aarch64-blue) | ✅ |
+| 692 | `speech_audio_format_validator` | speech | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
+| 693 | `speech_chunk_overlap_planner` | speech | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
+| 694 | `speech_diarization` | speech | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
+| 695 | `speech_multilingual` | speech | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
+| 696 | `speech_vad` | speech | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
+| 697 | `speech_vad_threshold_classifier` | speech | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
+| 698 | `whisper_streaming` | speech | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
+| 699 | `whisper_transcribe` | speech | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
+| 700 | `autograd_backprop_viz` | training | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
+| 701 | `autograd_custom_ops` | training | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
+| 702 | `autograd_gradient_clipping` | training | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
+| 703 | `checkpoint_resume` | training | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
+| 704 | `continuous_train_curriculum` | training | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
+| 705 | `continuous_train_federated_simulation` | training | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
+| 706 | `continuous_train_incremental` | training | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
+| 707 | `continuous_train_online_learning` | training | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
+| 708 | `data_preprocessing` | training | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
+| 709 | `data_sharded_shuffle` | training | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
+| 710 | `data_streaming_tokens` | training | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
+| 711 | `entrenar_autograd_training` | training | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
+| 712 | `entrenar_eval_metrics` | training | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
+| 713 | `few_shot_finetune` | training | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
+| 714 | `gradient_accumulation` | training | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
+| 715 | `hyperparameter_sweep` | training | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
+| 716 | `learning_rate_schedule` | training | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
+| 717 | `mixed_precision_training` | training | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
+| 718 | `pretrain_checkpoint_resume` | training | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
+| 719 | `pretrain_nan_guard` | training | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
+| 720 | `pretrain_synthetic_decreasing` | training | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
+| 721 | `train_distributed_sim` | training | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
+| 722 | `train_grad_accum` | training | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
+| 723 | `tsp_compare_tabu_vs_genetic` | tsp | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
+| 724 | `tsp_distance_matrix_explicit` | tsp | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
+| 725 | `tsp_solve_with_tabu` | tsp | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
+| 726 | `load_visualization` | visualization | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
+| 727 | `wasm_browser_inference` | wasm | ![wasm](https://img.shields.io/badge/-wasm-purple) | ✅ |
+| 728 | `wasm_capability_check` | wasm | ![wasm](https://img.shields.io/badge/-wasm-purple) | ✅ |
+| 729 | `wasm_memory_growth_policy` | wasm | ![wasm](https://img.shields.io/badge/-wasm-purple) | ✅ |
+| 730 | `wasm_model_loader` | wasm | ![wasm](https://img.shields.io/badge/-wasm-purple) | ✅ |
+| 731 | `wasm_module_cache_strategy` | wasm | ![wasm](https://img.shields.io/badge/-wasm-purple) | ✅ |
+| 732 | `wasm_progressive_loading` | wasm | ![wasm](https://img.shields.io/badge/-wasm-purple) | ✅ |
+| 733 | `wasm_streaming_compilation` | wasm | ![wasm](https://img.shields.io/badge/-wasm-purple) | ✅ |
+| 734 | `wasm_web_worker` | wasm | ![wasm](https://img.shields.io/badge/-wasm-purple) | ✅ |
+| 735 | `wasm_webgpu_acceleration` | wasm | ![wgpu](https://img.shields.io/badge/-wgpu-green) ![wasm](https://img.shields.io/badge/-wasm-purple) | ✅ |
 
 </details>
 <!-- RECIPE-TABLE-END -->

--- a/docs/roadmaps/roadmap.yaml
+++ b/docs/roadmaps/roadmap.yaml
@@ -1932,3 +1932,19 @@ roadmap:
   estimated_effort: null
   labels: []
   notes: null
+- id: PMAT-100
+  github_issue: null
+  item_type: task
+  title: 'PMAT-123: speech + wasm + simd (9 recipes)'
+  status: planned
+  priority: high
+  assigned_to: null
+  created: 2026-05-06T08:58:42Z
+  updated: 2026-05-06T08:58:42Z
+  spec: null
+  acceptance_criteria: []
+  phases: []
+  subtasks: []
+  estimated_effort: null
+  labels: []
+  notes: null

--- a/examples/simd/simd_alignment_validator.rs
+++ b/examples/simd/simd_alignment_validator.rs
@@ -1,0 +1,181 @@
+//! # SIMD Pointer Alignment Validator
+//!
+//! SIMD intrinsics require aligned data: SSE = 16 bytes, AVX/AVX2 = 32
+//! bytes, AVX-512 = 64 bytes, NEON = 16 bytes. Mis-aligned access on
+//! some ISAs faults; on others it's a slow scalar fallback. This recipe
+//! validates pointer alignment + recommends a load instruction.
+//!
+//! Demonstrates the **SIMD.5** recipe for PMAT-123 (simd coverage).
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml
+//! Citation: Intel Intrinsics Guide; ARM NEON Programmer's Guide.
+//!
+//! Run with: cargo run --example simd_alignment_validator
+//!
+//! Added by PMAT-123 (expand-cookbooks followup).
+
+use apr_cookbook::recipe::RecipeContext;
+use apr_cookbook::Result;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SimdIsa {
+    Sse,
+    Avx2,
+    Avx512,
+    Neon,
+}
+
+impl SimdIsa {
+    pub fn required_bytes(self) -> usize {
+        match self {
+            SimdIsa::Sse | SimdIsa::Neon => 16,
+            SimdIsa::Avx2 => 32,
+            SimdIsa::Avx512 => 64,
+        }
+    }
+
+    pub fn aligned_load_intrinsic(self) -> &'static str {
+        match self {
+            SimdIsa::Sse => "_mm_load_ps",
+            SimdIsa::Avx2 => "_mm256_load_ps",
+            SimdIsa::Avx512 => "_mm512_load_ps",
+            SimdIsa::Neon => "vld1q_f32",
+        }
+    }
+
+    pub fn unaligned_load_intrinsic(self) -> &'static str {
+        match self {
+            SimdIsa::Sse => "_mm_loadu_ps",
+            SimdIsa::Avx2 => "_mm256_loadu_ps",
+            SimdIsa::Avx512 => "_mm512_loadu_ps",
+            SimdIsa::Neon => "vld1q_f32_unaligned",
+        }
+    }
+}
+
+#[derive(Debug, PartialEq)]
+pub enum AlignmentVerdict {
+    AlignedUseFastLoad {
+        intrinsic: &'static str,
+    },
+    UnalignedUseSlowLoad {
+        intrinsic: &'static str,
+        misalignment_bytes: usize,
+    },
+    NullPointer,
+}
+
+pub fn classify(ptr_addr: usize, isa: SimdIsa) -> AlignmentVerdict {
+    if ptr_addr == 0 {
+        return AlignmentVerdict::NullPointer;
+    }
+    let req = isa.required_bytes();
+    let mis = ptr_addr % req;
+    if mis == 0 {
+        AlignmentVerdict::AlignedUseFastLoad {
+            intrinsic: isa.aligned_load_intrinsic(),
+        }
+    } else {
+        AlignmentVerdict::UnalignedUseSlowLoad {
+            intrinsic: isa.unaligned_load_intrinsic(),
+            misalignment_bytes: mis,
+        }
+    }
+}
+
+fn main() -> Result<()> {
+    let _ctx = RecipeContext::new("simd_alignment_validator")?;
+
+    for isa in [SimdIsa::Sse, SimdIsa::Avx2, SimdIsa::Avx512, SimdIsa::Neon] {
+        for addr in [0x1000usize, 0x1010, 0x1020, 0x1040] {
+            println!("ISA={isa:?} addr={addr:#x}  →  {:?}", classify(addr, isa));
+        }
+    }
+    println!("null: {:?}", classify(0, SimdIsa::Avx2));
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validator_runs() {
+        main().expect("recipe execution failed");
+    }
+
+    #[test]
+    fn aligned_address_uses_fast_load() {
+        // 0x1000 is aligned to 32 bytes for AVX2.
+        let v = classify(0x1000, SimdIsa::Avx2);
+        assert!(matches!(v, AlignmentVerdict::AlignedUseFastLoad { .. }));
+    }
+
+    #[test]
+    fn misaligned_address_uses_slow_load() {
+        // 0x1010 is 16-byte aligned but not 32-byte → slow load for AVX2.
+        let v = classify(0x1010, SimdIsa::Avx2);
+        assert!(matches!(
+            v,
+            AlignmentVerdict::UnalignedUseSlowLoad {
+                misalignment_bytes: 16,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn null_pointer_rejected() {
+        assert_eq!(classify(0, SimdIsa::Avx2), AlignmentVerdict::NullPointer);
+    }
+
+    #[test]
+    fn sse_requires_16_bytes() {
+        assert_eq!(SimdIsa::Sse.required_bytes(), 16);
+        assert!(matches!(
+            classify(0x1010, SimdIsa::Sse),
+            AlignmentVerdict::AlignedUseFastLoad { .. }
+        ));
+    }
+
+    #[test]
+    fn avx512_requires_64_bytes() {
+        assert_eq!(SimdIsa::Avx512.required_bytes(), 64);
+        // 0x1020 is 32-aligned but not 64-aligned → slow.
+        let v = classify(0x1020, SimdIsa::Avx512);
+        assert!(matches!(v, AlignmentVerdict::UnalignedUseSlowLoad { .. }));
+        // 0x1040 IS 64-aligned.
+        let v2 = classify(0x1040, SimdIsa::Avx512);
+        assert!(matches!(v2, AlignmentVerdict::AlignedUseFastLoad { .. }));
+    }
+
+    #[test]
+    fn neon_requires_16_bytes() {
+        assert_eq!(SimdIsa::Neon.required_bytes(), 16);
+        assert!(matches!(
+            classify(0x100, SimdIsa::Neon),
+            AlignmentVerdict::AlignedUseFastLoad { .. }
+        ));
+    }
+
+    #[test]
+    fn misalignment_bytes_reported_correctly() {
+        // 0x1004 is 4 bytes off 16-byte alignment.
+        let v = classify(0x1004, SimdIsa::Sse);
+        assert!(matches!(
+            v,
+            AlignmentVerdict::UnalignedUseSlowLoad {
+                misalignment_bytes: 4,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn intrinsic_names_match_isa() {
+        if let AlignmentVerdict::AlignedUseFastLoad { intrinsic } = classify(0x1000, SimdIsa::Avx2)
+        {
+            assert_eq!(intrinsic, "_mm256_load_ps");
+        }
+    }
+}

--- a/examples/simd/simd_horizontal_reduce_dispatcher.rs
+++ b/examples/simd/simd_horizontal_reduce_dispatcher.rs
@@ -1,0 +1,167 @@
+//! # SIMD Horizontal Reduce Dispatcher
+//!
+//! Horizontal reductions (sum/min/max across SIMD lanes) have ISA-
+//! specific intrinsics: AVX uses `_mm256_hadd_ps` + extract; AVX-512
+//! has `_mm512_reduce_*`. Lane width determines tree depth: 4 lanes
+//! → 2 levels, 8 → 3, 16 → 4. This recipe dispatches the operation
+//! + reports tree depth.
+//!
+//! Demonstrates the **SIMD.7** recipe for PMAT-123 (simd coverage).
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml
+//! Citation: Intel Intrinsics Guide §reduction.
+//!
+//! Run with: cargo run --example simd_horizontal_reduce_dispatcher
+//!
+//! Added by PMAT-123 (expand-cookbooks followup).
+
+use apr_cookbook::recipe::RecipeContext;
+use apr_cookbook::Result;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReduceOp {
+    Sum,
+    Min,
+    Max,
+}
+
+#[derive(Debug, PartialEq)]
+pub enum DispatchVerdict {
+    Ok { intrinsic: String, tree_depth: u32 },
+    UnsupportedLaneCount,
+    InvalidEmptyVector,
+}
+
+pub fn dispatch(op: ReduceOp, lane_count: u32) -> DispatchVerdict {
+    if lane_count == 0 {
+        return DispatchVerdict::InvalidEmptyVector;
+    }
+    if !lane_count.is_power_of_two() {
+        return DispatchVerdict::UnsupportedLaneCount;
+    }
+    if !(2..=16).contains(&lane_count) {
+        return DispatchVerdict::UnsupportedLaneCount;
+    }
+    let intrinsic = match (op, lane_count) {
+        (ReduceOp::Sum, 4) => "_mm_hadd_ps + extract".into(),
+        (ReduceOp::Sum, 8) => "_mm256_hadd_ps + extract".into(),
+        (ReduceOp::Sum, 16) => "_mm512_reduce_add_ps".into(),
+        (ReduceOp::Min, n) => format!("_mm{}_reduce_min_ps", n * 32),
+        (ReduceOp::Max, n) => format!("_mm{}_reduce_max_ps", n * 32),
+        (ReduceOp::Sum, 2) => "_mm_add_ps + scalar".into(),
+        _ => "scalar fallback".into(),
+    };
+    DispatchVerdict::Ok {
+        intrinsic,
+        tree_depth: lane_count.trailing_zeros(),
+    }
+}
+
+pub fn reduce_scalar(op: ReduceOp, values: &[f64]) -> Option<f64> {
+    if values.is_empty() {
+        return None;
+    }
+    let result = match op {
+        ReduceOp::Sum => values.iter().sum(),
+        ReduceOp::Min => values.iter().copied().fold(f64::INFINITY, f64::min),
+        ReduceOp::Max => values.iter().copied().fold(f64::NEG_INFINITY, f64::max),
+    };
+    Some(result)
+}
+
+fn main() -> Result<()> {
+    let _ctx = RecipeContext::new("simd_horizontal_reduce_dispatcher")?;
+
+    for op in [ReduceOp::Sum, ReduceOp::Min, ReduceOp::Max] {
+        for lanes in [2u32, 4, 8, 16, 32, 3] {
+            println!("{op:?} lanes={lanes}  →  {:?}", dispatch(op, lanes));
+        }
+    }
+    let v = [1.0, 2.0, 3.0, 4.0];
+    for op in [ReduceOp::Sum, ReduceOp::Min, ReduceOp::Max] {
+        println!("scalar {op:?}: {:?}", reduce_scalar(op, &v));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn dispatcher_runs() {
+        main().expect("recipe execution failed");
+    }
+
+    #[test]
+    fn sum_8_lanes_uses_avx() {
+        let v = dispatch(ReduceOp::Sum, 8);
+        if let DispatchVerdict::Ok { intrinsic, .. } = v {
+            assert!(intrinsic.contains("256"));
+        }
+    }
+
+    #[test]
+    fn sum_16_lanes_uses_avx512() {
+        let v = dispatch(ReduceOp::Sum, 16);
+        if let DispatchVerdict::Ok { intrinsic, .. } = v {
+            assert!(intrinsic.contains("512"));
+        }
+    }
+
+    #[test]
+    fn tree_depth_log2_of_lanes() {
+        if let DispatchVerdict::Ok { tree_depth, .. } = dispatch(ReduceOp::Sum, 4) {
+            assert_eq!(tree_depth, 2);
+        }
+        if let DispatchVerdict::Ok { tree_depth, .. } = dispatch(ReduceOp::Sum, 16) {
+            assert_eq!(tree_depth, 4);
+        }
+    }
+
+    #[test]
+    fn non_power_of_two_rejected() {
+        assert_eq!(
+            dispatch(ReduceOp::Sum, 3),
+            DispatchVerdict::UnsupportedLaneCount
+        );
+        assert_eq!(
+            dispatch(ReduceOp::Sum, 7),
+            DispatchVerdict::UnsupportedLaneCount
+        );
+    }
+
+    #[test]
+    fn over_16_lanes_unsupported() {
+        // Single-instruction reduce caps at 16 lanes (AVX-512).
+        assert_eq!(
+            dispatch(ReduceOp::Sum, 32),
+            DispatchVerdict::UnsupportedLaneCount
+        );
+    }
+
+    #[test]
+    fn zero_lanes_invalid() {
+        assert_eq!(
+            dispatch(ReduceOp::Sum, 0),
+            DispatchVerdict::InvalidEmptyVector
+        );
+    }
+
+    #[test]
+    fn scalar_sum_correct() {
+        assert_eq!(reduce_scalar(ReduceOp::Sum, &[1.0, 2.0, 3.0]), Some(6.0));
+    }
+
+    #[test]
+    fn scalar_min_max_correct() {
+        let v = [3.0, 1.0, 4.0, 1.5];
+        assert_eq!(reduce_scalar(ReduceOp::Min, &v), Some(1.0));
+        assert_eq!(reduce_scalar(ReduceOp::Max, &v), Some(4.0));
+    }
+
+    #[test]
+    fn scalar_empty_yields_none() {
+        assert!(reduce_scalar(ReduceOp::Sum, &[]).is_none());
+    }
+}

--- a/examples/simd/simd_unroll_factor_picker.rs
+++ b/examples/simd/simd_unroll_factor_picker.rs
@@ -1,0 +1,151 @@
+//! # SIMD Loop Unroll Factor Picker
+//!
+//! Loop unrolling boosts SIMD throughput by hiding pipeline latency,
+//! but too aggressive a factor exhausts registers and spills to memory.
+//! Rule of thumb: 4-way unroll for AVX2 (16 ymm registers), 8-way for
+//! AVX-512 (32 zmm registers). This recipe picks the factor + checks
+//! against register pressure.
+//!
+//! Demonstrates the **SIMD.6** recipe for PMAT-123 (simd coverage).
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml
+//! Citation: Hennessy & Patterson, Computer Architecture (6th ed.) §3.4.
+//!
+//! Run with: cargo run --example simd_unroll_factor_picker
+//!
+//! Added by PMAT-123 (expand-cookbooks followup).
+
+use apr_cookbook::recipe::RecipeContext;
+use apr_cookbook::Result;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SimdIsa {
+    Sse,
+    Avx2,
+    Avx512,
+}
+
+impl SimdIsa {
+    pub fn architectural_registers(self) -> u32 {
+        match self {
+            SimdIsa::Sse => 16,
+            SimdIsa::Avx2 => 16,
+            SimdIsa::Avx512 => 32,
+        }
+    }
+
+    pub fn typical_unroll(self) -> u32 {
+        match self {
+            SimdIsa::Sse => 4,
+            SimdIsa::Avx2 => 4,
+            SimdIsa::Avx512 => 8,
+        }
+    }
+}
+
+#[derive(Debug, PartialEq)]
+pub enum UnrollVerdict {
+    Ok { factor: u32 },
+    SpillsRegisters { needed: u32, available: u32 },
+    InvalidWorkPerIteration,
+}
+
+pub fn pick(isa: SimdIsa, registers_per_iteration: u32) -> UnrollVerdict {
+    if registers_per_iteration == 0 {
+        return UnrollVerdict::InvalidWorkPerIteration;
+    }
+    let architectural = isa.architectural_registers();
+    let typical = isa.typical_unroll();
+    let needed = registers_per_iteration.saturating_mul(typical);
+    if needed > architectural {
+        // Reduce factor until it fits.
+        let max_factor = architectural / registers_per_iteration;
+        if max_factor == 0 {
+            return UnrollVerdict::SpillsRegisters {
+                needed: registers_per_iteration,
+                available: architectural,
+            };
+        }
+        return UnrollVerdict::Ok { factor: max_factor };
+    }
+    UnrollVerdict::Ok { factor: typical }
+}
+
+fn main() -> Result<()> {
+    let _ctx = RecipeContext::new("simd_unroll_factor_picker")?;
+
+    for isa in [SimdIsa::Sse, SimdIsa::Avx2, SimdIsa::Avx512] {
+        for r in [1u32, 2, 4, 8, 20] {
+            println!("ISA={isa:?} regs/iter={r}  →  {:?}", pick(isa, r));
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn picker_runs() {
+        main().expect("recipe execution failed");
+    }
+
+    #[test]
+    fn typical_avx2_picks_4x() {
+        // 2 regs/iter × 4 unroll = 8 regs ≤ 16 architectural.
+        assert_eq!(pick(SimdIsa::Avx2, 2), UnrollVerdict::Ok { factor: 4 });
+    }
+
+    #[test]
+    fn typical_avx512_picks_8x() {
+        assert_eq!(pick(SimdIsa::Avx512, 2), UnrollVerdict::Ok { factor: 8 });
+    }
+
+    #[test]
+    fn high_pressure_reduces_factor() {
+        // 5 regs/iter × 4 = 20 > 16 → reduce to 16 / 5 = 3.
+        assert_eq!(pick(SimdIsa::Avx2, 5), UnrollVerdict::Ok { factor: 3 });
+    }
+
+    #[test]
+    fn extreme_pressure_spills() {
+        // 20 regs/iter > 16 architectural → can't fit even one iteration.
+        let v = pick(SimdIsa::Avx2, 20);
+        assert!(matches!(v, UnrollVerdict::SpillsRegisters { .. }));
+    }
+
+    #[test]
+    fn zero_regs_invalid() {
+        assert_eq!(
+            pick(SimdIsa::Avx2, 0),
+            UnrollVerdict::InvalidWorkPerIteration
+        );
+    }
+
+    #[test]
+    fn architectural_register_counts_correct() {
+        assert_eq!(SimdIsa::Sse.architectural_registers(), 16);
+        assert_eq!(SimdIsa::Avx2.architectural_registers(), 16);
+        assert_eq!(SimdIsa::Avx512.architectural_registers(), 32);
+    }
+
+    #[test]
+    fn typical_unroll_factors_correct() {
+        assert_eq!(SimdIsa::Sse.typical_unroll(), 4);
+        assert_eq!(SimdIsa::Avx2.typical_unroll(), 4);
+        assert_eq!(SimdIsa::Avx512.typical_unroll(), 8);
+    }
+
+    #[test]
+    fn avx512_with_4_regs_per_iter_picks_8x() {
+        // 4 × 8 = 32 ≤ 32 architectural → fits exactly.
+        assert_eq!(pick(SimdIsa::Avx512, 4), UnrollVerdict::Ok { factor: 8 });
+    }
+
+    #[test]
+    fn avx512_with_5_regs_per_iter_reduces() {
+        // 5 × 8 = 40 > 32 → reduce to 32 / 5 = 6.
+        assert_eq!(pick(SimdIsa::Avx512, 5), UnrollVerdict::Ok { factor: 6 });
+    }
+}

--- a/examples/speech/speech_audio_format_validator.rs
+++ b/examples/speech/speech_audio_format_validator.rs
@@ -1,0 +1,196 @@
+//! # Speech Audio Format Validator
+//!
+//! Whisper accepts 16-kHz mono WAV/FLAC/MP3 input. This recipe builds
+//! the format detector (RIFF/fLaC/ID3 magic bytes) + sample-rate
+//! envelope + channel-count guard. Wrong rate → resample required;
+//! wrong channels → downmix required.
+//!
+//! Demonstrates the **SPEECH.2** recipe for PMAT-123 (speech coverage —
+//! closing F-invariant gap from 1 → 4).
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml
+//! Citation: Radford et al. (2022). Robust Speech Recognition via Large-Scale Weak Supervision (Whisper). arXiv:2212.04356.
+//!
+//! Run with: cargo run --example speech_audio_format_validator
+//!
+//! Added by PMAT-123 (expand-cookbooks followup).
+
+use apr_cookbook::recipe::RecipeContext;
+use apr_cookbook::Result;
+
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum AudioFormat {
+    Wav,
+    Flac,
+    Mp3,
+    Unknown,
+}
+
+#[derive(Debug, PartialEq)]
+pub enum FormatVerdict {
+    Ok { format: AudioFormat },
+    HeaderTooShort,
+    UnknownFormat,
+}
+
+pub fn detect_format(magic: &[u8]) -> FormatVerdict {
+    if magic.len() < 4 {
+        return FormatVerdict::HeaderTooShort;
+    }
+    if &magic[..4] == b"RIFF" && magic.len() >= 12 && &magic[8..12] == b"WAVE" {
+        return FormatVerdict::Ok {
+            format: AudioFormat::Wav,
+        };
+    }
+    if &magic[..4] == b"fLaC" {
+        return FormatVerdict::Ok {
+            format: AudioFormat::Flac,
+        };
+    }
+    if &magic[..3] == b"ID3" || (magic[0] == 0xFF && (magic[1] & 0xE0) == 0xE0) {
+        return FormatVerdict::Ok {
+            format: AudioFormat::Mp3,
+        };
+    }
+    FormatVerdict::UnknownFormat
+}
+
+#[derive(Debug, PartialEq)]
+pub enum AudioVerdict {
+    NativelySupported,
+    NeedsResample { current_rate: u32, target_rate: u32 },
+    NeedsDownmix { channels: u8 },
+    InvalidShape,
+}
+
+const TARGET_RATE: u32 = 16_000;
+
+pub fn classify_audio(sample_rate: u32, channels: u8) -> AudioVerdict {
+    if sample_rate == 0 || channels == 0 {
+        return AudioVerdict::InvalidShape;
+    }
+    if channels > 1 {
+        return AudioVerdict::NeedsDownmix { channels };
+    }
+    if sample_rate == TARGET_RATE {
+        return AudioVerdict::NativelySupported;
+    }
+    AudioVerdict::NeedsResample {
+        current_rate: sample_rate,
+        target_rate: TARGET_RATE,
+    }
+}
+
+fn main() -> Result<()> {
+    let _ctx = RecipeContext::new("speech_audio_format_validator")?;
+
+    let wav = b"RIFF\x00\x00\x00\x00WAVEfmt ";
+    let flac = b"fLaC\x00\x00\x00\x22";
+    let mp3 = b"ID3\x04\x00\x00\x00\x00";
+    println!("WAV:  {:?}", detect_format(wav));
+    println!("FLAC: {:?}", detect_format(flac));
+    println!("MP3:  {:?}", detect_format(mp3));
+    println!("?:    {:?}", detect_format(b"XYZ "));
+
+    for (rate, ch) in [(16_000, 1u8), (44_100, 1), (16_000, 2), (0, 1)] {
+        println!("rate={rate} ch={ch}  →  {:?}", classify_audio(rate, ch));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validator_runs() {
+        main().expect("recipe execution failed");
+    }
+
+    #[test]
+    fn wav_magic_detected() {
+        let v = detect_format(b"RIFF\x00\x00\x00\x00WAVEfmt ");
+        assert!(matches!(
+            v,
+            FormatVerdict::Ok {
+                format: AudioFormat::Wav
+            }
+        ));
+    }
+
+    #[test]
+    fn flac_magic_detected() {
+        let v = detect_format(b"fLaC\x00\x00\x00\x22");
+        assert!(matches!(
+            v,
+            FormatVerdict::Ok {
+                format: AudioFormat::Flac
+            }
+        ));
+    }
+
+    #[test]
+    fn mp3_id3_magic_detected() {
+        let v = detect_format(b"ID3\x04\x00\x00\x00\x00");
+        assert!(matches!(
+            v,
+            FormatVerdict::Ok {
+                format: AudioFormat::Mp3
+            }
+        ));
+    }
+
+    #[test]
+    fn mp3_frame_sync_detected() {
+        // MP3 without ID3: frame starts with 0xFFF (sync word).
+        let v = detect_format(&[0xFF, 0xFB, 0x90, 0x44]);
+        assert!(matches!(
+            v,
+            FormatVerdict::Ok {
+                format: AudioFormat::Mp3
+            }
+        ));
+    }
+
+    #[test]
+    fn truncated_header_rejected() {
+        assert_eq!(detect_format(b"RI"), FormatVerdict::HeaderTooShort);
+    }
+
+    #[test]
+    fn riff_without_wave_rejected() {
+        // RIFF could be AVI (RIFF + AVI ); check requires WAVE form.
+        let v = detect_format(b"RIFF\x00\x00\x00\x00AVI ");
+        assert!(matches!(v, FormatVerdict::UnknownFormat));
+    }
+
+    #[test]
+    fn natively_supported_at_16khz_mono() {
+        assert_eq!(classify_audio(16_000, 1), AudioVerdict::NativelySupported);
+    }
+
+    #[test]
+    fn needs_resample_at_44100() {
+        let v = classify_audio(44_100, 1);
+        assert!(matches!(v, AudioVerdict::NeedsResample { .. }));
+    }
+
+    #[test]
+    fn needs_downmix_for_stereo() {
+        let v = classify_audio(16_000, 2);
+        assert!(matches!(v, AudioVerdict::NeedsDownmix { channels: 2 }));
+    }
+
+    #[test]
+    fn zero_rate_or_channels_invalid() {
+        assert_eq!(classify_audio(0, 1), AudioVerdict::InvalidShape);
+        assert_eq!(classify_audio(16_000, 0), AudioVerdict::InvalidShape);
+    }
+
+    #[test]
+    fn downmix_takes_priority_over_resample() {
+        // Stereo at non-target rate: downmix first (cheaper), then resample.
+        let v = classify_audio(44_100, 2);
+        assert!(matches!(v, AudioVerdict::NeedsDownmix { .. }));
+    }
+}

--- a/examples/speech/speech_chunk_overlap_planner.rs
+++ b/examples/speech/speech_chunk_overlap_planner.rs
@@ -1,0 +1,152 @@
+//! # Speech Streaming Chunk Overlap Planner
+//!
+//! Streaming Whisper transcription windows audio into chunks (default
+//! 30 s) with overlap (default 5 s) so the model sees boundary
+//! context. Constraints: 5 s ≤ chunk_secs ≤ 30 s; 0 ≤ overlap_secs <
+//! chunk_secs / 2 (avoid degenerate cases). This recipe builds the
+//! validator + total-windows calculator.
+//!
+//! Demonstrates the **SPEECH.4** recipe for PMAT-123 (speech coverage —
+//! closing F-invariant gap from 1 → 4).
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml
+//! Citation: Radford et al. (2022). Whisper §3.4 — Long-form transcription.
+//!
+//! Run with: cargo run --example speech_chunk_overlap_planner
+//!
+//! Added by PMAT-123 (expand-cookbooks followup).
+
+use apr_cookbook::recipe::RecipeContext;
+use apr_cookbook::Result;
+
+#[derive(Debug, PartialEq)]
+pub enum ChunkVerdict {
+    Ok { num_windows: u32 },
+    ChunkTooShort,
+    ChunkTooLong,
+    OverlapNegative,
+    OverlapTooLarge,
+    InvalidAudioLength,
+}
+
+const MIN_CHUNK_SECS: f64 = 5.0;
+const MAX_CHUNK_SECS: f64 = 30.0;
+
+pub fn plan(audio_secs: f64, chunk_secs: f64, overlap_secs: f64) -> ChunkVerdict {
+    if !audio_secs.is_finite() || audio_secs <= 0.0 {
+        return ChunkVerdict::InvalidAudioLength;
+    }
+    if !chunk_secs.is_finite() || chunk_secs < MIN_CHUNK_SECS {
+        return ChunkVerdict::ChunkTooShort;
+    }
+    if chunk_secs > MAX_CHUNK_SECS {
+        return ChunkVerdict::ChunkTooLong;
+    }
+    if !overlap_secs.is_finite() || overlap_secs < 0.0 {
+        return ChunkVerdict::OverlapNegative;
+    }
+    if overlap_secs >= chunk_secs / 2.0 {
+        return ChunkVerdict::OverlapTooLarge;
+    }
+    let stride = chunk_secs - overlap_secs;
+    let num_windows = if audio_secs <= chunk_secs {
+        1
+    } else {
+        // ceil((audio - chunk) / stride) + 1
+        let extra = audio_secs - chunk_secs;
+        (extra / stride).ceil() as u32 + 1
+    };
+    ChunkVerdict::Ok { num_windows }
+}
+
+fn main() -> Result<()> {
+    let _ctx = RecipeContext::new("speech_chunk_overlap_planner")?;
+
+    let cases = [
+        (60.0, 30.0, 5.0),
+        (120.0, 30.0, 5.0),
+        (10.0, 30.0, 5.0),
+        (60.0, 3.0, 1.0),
+        (60.0, 30.0, 20.0),
+        (-1.0, 30.0, 5.0),
+    ];
+    for (audio, chunk, overlap) in cases {
+        println!(
+            "audio={audio}s chunk={chunk}s overlap={overlap}s  →  {:?}",
+            plan(audio, chunk, overlap)
+        );
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn planner_runs() {
+        main().expect("recipe execution failed");
+    }
+
+    #[test]
+    fn audio_shorter_than_chunk_yields_one_window() {
+        let v = plan(10.0, 30.0, 5.0);
+        assert_eq!(v, ChunkVerdict::Ok { num_windows: 1 });
+    }
+
+    #[test]
+    fn typical_60s_30s_chunk_5s_overlap() {
+        // stride = 25; (60 - 30) / 25 = 1.2 → ceil = 2 → 3 windows.
+        let v = plan(60.0, 30.0, 5.0);
+        assert_eq!(v, ChunkVerdict::Ok { num_windows: 3 });
+    }
+
+    #[test]
+    fn overlap_zero_no_redundant_compute() {
+        // 60 / 30 = 2 windows.
+        let v = plan(60.0, 30.0, 0.0);
+        assert_eq!(v, ChunkVerdict::Ok { num_windows: 2 });
+    }
+
+    #[test]
+    fn chunk_too_short_rejected() {
+        assert_eq!(plan(60.0, 3.0, 1.0), ChunkVerdict::ChunkTooShort);
+    }
+
+    #[test]
+    fn chunk_too_long_rejected() {
+        assert_eq!(plan(60.0, 60.0, 5.0), ChunkVerdict::ChunkTooLong);
+    }
+
+    #[test]
+    fn negative_overlap_rejected() {
+        assert_eq!(plan(60.0, 30.0, -1.0), ChunkVerdict::OverlapNegative);
+    }
+
+    #[test]
+    fn overlap_at_or_above_half_chunk_rejected() {
+        // chunk=30, half=15; overlap ≥ 15 → reject.
+        assert_eq!(plan(60.0, 30.0, 15.0), ChunkVerdict::OverlapTooLarge);
+        assert_eq!(plan(60.0, 30.0, 20.0), ChunkVerdict::OverlapTooLarge);
+    }
+
+    #[test]
+    fn audio_zero_or_negative_rejected() {
+        assert_eq!(plan(0.0, 30.0, 5.0), ChunkVerdict::InvalidAudioLength);
+        assert_eq!(plan(-5.0, 30.0, 5.0), ChunkVerdict::InvalidAudioLength);
+    }
+
+    #[test]
+    fn long_audio_scales_linearly() {
+        // 120 s audio with 30/5 → stride 25; (120 - 30) / 25 = 3.6 → ceil 4 → 5 windows.
+        let v = plan(120.0, 30.0, 5.0);
+        assert_eq!(v, ChunkVerdict::Ok { num_windows: 5 });
+    }
+
+    #[test]
+    fn at_chunk_boundary_one_window() {
+        // audio == chunk → 1 window (boundary).
+        let v = plan(30.0, 30.0, 5.0);
+        assert_eq!(v, ChunkVerdict::Ok { num_windows: 1 });
+    }
+}

--- a/examples/speech/speech_vad_threshold_classifier.rs
+++ b/examples/speech/speech_vad_threshold_classifier.rs
@@ -1,0 +1,142 @@
+//! # Speech VAD Threshold Classifier
+//!
+//! Voice Activity Detection (VAD) tags audio frames as speech vs.
+//! silence by comparing per-frame RMS energy against a threshold. Too
+//! low: false positives; too high: clipped speech. Recommended
+//! envelope: −60 dBFS to −20 dBFS. This recipe builds the classifier +
+//! adaptive-threshold heuristic.
+//!
+//! Demonstrates the **SPEECH.3** recipe for PMAT-123 (speech coverage —
+//! closing F-invariant gap).
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml
+//! Citation: Sohn et al. (1999). A statistical model-based voice activity detection. IEEE SPL 6(1).
+//!
+//! Run with: cargo run --example speech_vad_threshold_classifier
+//!
+//! Added by PMAT-123 (expand-cookbooks followup).
+
+use apr_cookbook::recipe::RecipeContext;
+use apr_cookbook::Result;
+
+#[derive(Debug, PartialEq)]
+pub enum VadVerdict {
+    Speech,
+    Silence,
+    InvalidEnergy,
+}
+
+const MIN_DB: f64 = -60.0;
+const MAX_DB: f64 = -20.0;
+
+pub fn classify(frame_rms_dbfs: f64, threshold_dbfs: f64) -> VadVerdict {
+    if !frame_rms_dbfs.is_finite() || !threshold_dbfs.is_finite() {
+        return VadVerdict::InvalidEnergy;
+    }
+    if !(MIN_DB..=MAX_DB + 5.0).contains(&threshold_dbfs) {
+        return VadVerdict::InvalidEnergy;
+    }
+    if frame_rms_dbfs >= threshold_dbfs {
+        VadVerdict::Speech
+    } else {
+        VadVerdict::Silence
+    }
+}
+
+pub fn adaptive_threshold(noise_floor_dbfs: f64, headroom_db: f64) -> Option<f64> {
+    if !noise_floor_dbfs.is_finite() || !headroom_db.is_finite() {
+        return None;
+    }
+    if headroom_db <= 0.0 || headroom_db > 30.0 {
+        return None;
+    }
+    let proposed = noise_floor_dbfs + headroom_db;
+    Some(proposed.clamp(MIN_DB, MAX_DB))
+}
+
+fn main() -> Result<()> {
+    let _ctx = RecipeContext::new("speech_vad_threshold_classifier")?;
+
+    for (rms, thresh) in [(-30.0, -40.0), (-50.0, -40.0), (-25.0, -25.0)] {
+        println!("rms={rms} thresh={thresh}  →  {:?}", classify(rms, thresh));
+    }
+    for (floor, head) in [(-55.0, 10.0), (-40.0, 6.0), (-50.0, 50.0)] {
+        println!(
+            "floor={floor} headroom={head}  →  {:?}",
+            adaptive_threshold(floor, head)
+        );
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn classifier_runs() {
+        main().expect("recipe execution failed");
+    }
+
+    #[test]
+    fn high_rms_above_threshold_speech() {
+        assert_eq!(classify(-30.0, -40.0), VadVerdict::Speech);
+    }
+
+    #[test]
+    fn low_rms_below_threshold_silence() {
+        assert_eq!(classify(-50.0, -40.0), VadVerdict::Silence);
+    }
+
+    #[test]
+    fn at_threshold_treated_as_speech() {
+        // ≥ threshold inclusive — avoid edge flicker.
+        assert_eq!(classify(-40.0, -40.0), VadVerdict::Speech);
+    }
+
+    #[test]
+    fn nan_energy_invalid() {
+        assert_eq!(classify(f64::NAN, -40.0), VadVerdict::InvalidEnergy);
+        assert_eq!(classify(-30.0, f64::NAN), VadVerdict::InvalidEnergy);
+    }
+
+    #[test]
+    fn out_of_range_threshold_invalid() {
+        // > MAX_DB + headroom.
+        assert_eq!(classify(-30.0, 0.0), VadVerdict::InvalidEnergy);
+        // < MIN_DB.
+        assert_eq!(classify(-30.0, -100.0), VadVerdict::InvalidEnergy);
+    }
+
+    #[test]
+    fn adaptive_typical_returns_clamped_value() {
+        // Floor=-55, head=10 → -45.
+        assert!((adaptive_threshold(-55.0, 10.0).unwrap() - (-45.0)).abs() < 1e-9);
+    }
+
+    #[test]
+    fn adaptive_clamps_to_max_db() {
+        // Floor=-25, head=20 → -5, clamps to MAX_DB.
+        let t = adaptive_threshold(-25.0, 20.0).unwrap();
+        assert!((t - MAX_DB).abs() < 1e-9);
+    }
+
+    #[test]
+    fn adaptive_clamps_to_min_db() {
+        // Floor=-100, head=5 → -95, clamps to MIN_DB.
+        let t = adaptive_threshold(-100.0, 5.0).unwrap();
+        assert!((t - MIN_DB).abs() < 1e-9);
+    }
+
+    #[test]
+    fn adaptive_zero_or_negative_headroom_rejected() {
+        assert!(adaptive_threshold(-50.0, 0.0).is_none());
+        assert!(adaptive_threshold(-50.0, -5.0).is_none());
+    }
+
+    #[test]
+    fn adaptive_excessive_headroom_rejected() {
+        // Headroom > 30 dB is unrealistic and likely a mis-config.
+        assert!(adaptive_threshold(-50.0, 50.0).is_none());
+    }
+}

--- a/examples/wasm/wasm_capability_check.rs
+++ b/examples/wasm/wasm_capability_check.rs
@@ -1,0 +1,188 @@
+//! # WASM Capability Detector
+//!
+//! Browsers vary in WASM feature support: SIMD128 (Chrome 91+, Firefox
+//! 89+, Safari 16.4+), threads (requires SAB + COOP/COEP headers),
+//! bulk-memory (universal as of 2022). This recipe builds the
+//! capability classifier + degradation tier.
+//!
+//! Demonstrates the **WASM.7** recipe for PMAT-123 (wasm coverage).
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml
+//! Citation: WebAssembly proposals (https://github.com/WebAssembly/proposals)
+//!
+//! Run with: cargo run --example wasm_capability_check
+//!
+//! Added by PMAT-123 (expand-cookbooks followup).
+
+use apr_cookbook::recipe::RecipeContext;
+use apr_cookbook::Result;
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct WasmCapabilities {
+    pub simd128: bool,
+    pub threads: bool,
+    pub bulk_memory: bool,
+    pub reference_types: bool,
+    pub multi_value: bool,
+}
+
+#[derive(Debug, PartialEq)]
+pub enum FeatureTier {
+    Modern,      // SIMD + threads + bulk + reftypes + multi-value
+    Standard,    // bulk-memory + multi-value (2022 baseline)
+    Legacy,      // MVP only
+    Unsupported, // missing core requirement
+}
+
+pub fn classify(caps: WasmCapabilities) -> FeatureTier {
+    if !caps.bulk_memory {
+        return FeatureTier::Unsupported;
+    }
+    if caps.simd128 && caps.threads && caps.reference_types && caps.multi_value {
+        return FeatureTier::Modern;
+    }
+    if caps.bulk_memory && caps.multi_value {
+        return FeatureTier::Standard;
+    }
+    FeatureTier::Legacy
+}
+
+#[derive(Debug, PartialEq)]
+pub enum ThreadsVerdict {
+    Available,
+    MissingSharedArrayBuffer,
+    MissingCrossOriginIsolation,
+    MissingThreadProposal,
+}
+
+pub fn check_threads(
+    has_shared_array_buffer: bool,
+    cross_origin_isolated: bool,
+    threads_proposal: bool,
+) -> ThreadsVerdict {
+    if !threads_proposal {
+        return ThreadsVerdict::MissingThreadProposal;
+    }
+    if !has_shared_array_buffer {
+        return ThreadsVerdict::MissingSharedArrayBuffer;
+    }
+    if !cross_origin_isolated {
+        return ThreadsVerdict::MissingCrossOriginIsolation;
+    }
+    ThreadsVerdict::Available
+}
+
+fn main() -> Result<()> {
+    let _ctx = RecipeContext::new("wasm_capability_check")?;
+
+    let modern = WasmCapabilities {
+        simd128: true,
+        threads: true,
+        bulk_memory: true,
+        reference_types: true,
+        multi_value: true,
+    };
+    let baseline = WasmCapabilities {
+        bulk_memory: true,
+        multi_value: true,
+        ..Default::default()
+    };
+    let mvp = WasmCapabilities::default();
+
+    println!("modern:   {:?}", classify(modern));
+    println!("baseline: {:?}", classify(baseline));
+    println!("mvp:      {:?}", classify(mvp));
+
+    println!("threads (full): {:?}", check_threads(true, true, true));
+    println!("threads (no COOP): {:?}", check_threads(true, false, true));
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn modern() -> WasmCapabilities {
+        WasmCapabilities {
+            simd128: true,
+            threads: true,
+            bulk_memory: true,
+            reference_types: true,
+            multi_value: true,
+        }
+    }
+
+    #[test]
+    fn checker_runs() {
+        main().expect("recipe execution failed");
+    }
+
+    #[test]
+    fn full_caps_classified_modern() {
+        assert_eq!(classify(modern()), FeatureTier::Modern);
+    }
+
+    #[test]
+    fn no_bulk_memory_unsupported() {
+        let mut c = modern();
+        c.bulk_memory = false;
+        assert_eq!(classify(c), FeatureTier::Unsupported);
+    }
+
+    #[test]
+    fn baseline_2022_classified_standard() {
+        let c = WasmCapabilities {
+            bulk_memory: true,
+            multi_value: true,
+            ..Default::default()
+        };
+        assert_eq!(classify(c), FeatureTier::Standard);
+    }
+
+    #[test]
+    fn missing_simd_drops_to_standard() {
+        let mut c = modern();
+        c.simd128 = false;
+        assert_eq!(classify(c), FeatureTier::Standard);
+    }
+
+    #[test]
+    fn missing_multi_value_drops_to_legacy() {
+        let mut c = modern();
+        c.multi_value = false;
+        c.simd128 = false;
+        c.threads = false;
+        c.reference_types = false;
+        assert_eq!(classify(c), FeatureTier::Legacy);
+    }
+
+    #[test]
+    fn threads_full_stack_available() {
+        assert_eq!(check_threads(true, true, true), ThreadsVerdict::Available);
+    }
+
+    #[test]
+    fn threads_proposal_missing_rejected() {
+        assert_eq!(
+            check_threads(true, true, false),
+            ThreadsVerdict::MissingThreadProposal
+        );
+    }
+
+    #[test]
+    fn threads_sab_missing_rejected() {
+        assert_eq!(
+            check_threads(false, true, true),
+            ThreadsVerdict::MissingSharedArrayBuffer
+        );
+    }
+
+    #[test]
+    fn threads_no_coop_rejected() {
+        // SAB requires Cross-Origin-Opener-Policy + Cross-Origin-Embedder-Policy.
+        assert_eq!(
+            check_threads(true, false, true),
+            ThreadsVerdict::MissingCrossOriginIsolation
+        );
+    }
+}

--- a/examples/wasm/wasm_memory_growth_policy.rs
+++ b/examples/wasm/wasm_memory_growth_policy.rs
@@ -1,0 +1,168 @@
+//! # WASM Memory Growth Policy
+//!
+//! WebAssembly linear memory grows in 64-KiB pages. Browsers cap the
+//! limit (Chromium 4 GiB on 64-bit, 1 GiB on 32-bit; Safari ~2 GiB).
+//! Growth strategies: 2× doubling (fast, fragments), fixed-step
+//! (predictable, slow), reservation (over-commit upfront). This recipe
+//! builds the policy picker + page-budget validator.
+//!
+//! Demonstrates the **WASM.6** recipe for PMAT-123 (wasm coverage).
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml
+//! Citation: WebAssembly Core Spec §4.2.8 (Memory Instances)
+//!
+//! Run with: cargo run --example wasm_memory_growth_policy
+//!
+//! Added by PMAT-123 (expand-cookbooks followup).
+
+use apr_cookbook::recipe::RecipeContext;
+use apr_cookbook::Result;
+
+const PAGE_BYTES: u32 = 65_536;
+const MAX_PAGES_32BIT: u32 = 16_384; // 1 GiB
+const MAX_PAGES_64BIT: u32 = 65_536; // 4 GiB
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GrowthStrategy {
+    Doubling,
+    FixedStep,
+    Reservation,
+}
+
+#[derive(Debug, PartialEq)]
+pub enum PolicyVerdict {
+    Ok,
+    ExceedsBrowserCap { requested: u32, max: u32 },
+    InvalidInitialPages,
+}
+
+pub fn validate_pages(initial: u32, max: u32, is_64bit: bool) -> PolicyVerdict {
+    if initial == 0 {
+        return PolicyVerdict::InvalidInitialPages;
+    }
+    let cap = if is_64bit {
+        MAX_PAGES_64BIT
+    } else {
+        MAX_PAGES_32BIT
+    };
+    if max > cap {
+        return PolicyVerdict::ExceedsBrowserCap {
+            requested: max,
+            max: cap,
+        };
+    }
+    if initial > max {
+        return PolicyVerdict::InvalidInitialPages;
+    }
+    PolicyVerdict::Ok
+}
+
+pub fn next_size(current_pages: u32, strategy: GrowthStrategy, fixed_step: u32) -> u32 {
+    match strategy {
+        GrowthStrategy::Doubling => current_pages.saturating_mul(2).max(1),
+        GrowthStrategy::FixedStep => current_pages.saturating_add(fixed_step.max(1)),
+        GrowthStrategy::Reservation => current_pages, // reservation pre-allocates; no growth
+    }
+}
+
+pub fn pages_to_bytes(pages: u32) -> u64 {
+    u64::from(pages) * u64::from(PAGE_BYTES)
+}
+
+fn main() -> Result<()> {
+    let _ctx = RecipeContext::new("wasm_memory_growth_policy")?;
+
+    println!("16 pages → {} bytes", pages_to_bytes(16));
+    println!(
+        "validate(16, 256, 32bit): {:?}",
+        validate_pages(16, 256, false)
+    );
+    println!(
+        "validate(16, 65536, 32bit): {:?}",
+        validate_pages(16, 65_536, false)
+    );
+    for s in [
+        GrowthStrategy::Doubling,
+        GrowthStrategy::FixedStep,
+        GrowthStrategy::Reservation,
+    ] {
+        println!("next_size(16, {s:?}, 4) = {}", next_size(16, s, 4));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn policy_runs() {
+        main().expect("recipe execution failed");
+    }
+
+    #[test]
+    fn typical_initial_within_cap() {
+        assert_eq!(validate_pages(16, 256, false), PolicyVerdict::Ok);
+    }
+
+    #[test]
+    fn zero_initial_invalid() {
+        assert_eq!(
+            validate_pages(0, 256, false),
+            PolicyVerdict::InvalidInitialPages
+        );
+    }
+
+    #[test]
+    fn initial_above_max_invalid() {
+        assert_eq!(
+            validate_pages(500, 256, false),
+            PolicyVerdict::InvalidInitialPages
+        );
+    }
+
+    #[test]
+    fn exceeds_32bit_cap_rejected() {
+        let v = validate_pages(16, MAX_PAGES_32BIT + 1, false);
+        assert!(matches!(v, PolicyVerdict::ExceedsBrowserCap { .. }));
+    }
+
+    #[test]
+    fn at_64bit_cap_passes() {
+        assert_eq!(validate_pages(16, MAX_PAGES_64BIT, true), PolicyVerdict::Ok);
+    }
+
+    #[test]
+    fn pages_to_bytes_64kib_per_page() {
+        assert_eq!(pages_to_bytes(1), 65_536);
+        assert_eq!(pages_to_bytes(16), 16 * 65_536);
+    }
+
+    #[test]
+    fn doubling_strategy_2x() {
+        assert_eq!(next_size(16, GrowthStrategy::Doubling, 0), 32);
+    }
+
+    #[test]
+    fn fixed_step_adds_increment() {
+        assert_eq!(next_size(16, GrowthStrategy::FixedStep, 4), 20);
+    }
+
+    #[test]
+    fn reservation_does_not_grow() {
+        assert_eq!(next_size(16, GrowthStrategy::Reservation, 999), 16);
+    }
+
+    #[test]
+    fn doubling_saturates_at_max() {
+        // Doesn't panic on overflow.
+        let v = next_size(u32::MAX, GrowthStrategy::Doubling, 0);
+        assert_eq!(v, u32::MAX);
+    }
+
+    #[test]
+    fn fixed_step_zero_clamps_to_one() {
+        // Don't get stuck at the same size — clamp to ≥ 1.
+        assert_eq!(next_size(16, GrowthStrategy::FixedStep, 0), 17);
+    }
+}

--- a/examples/wasm/wasm_module_cache_strategy.rs
+++ b/examples/wasm/wasm_module_cache_strategy.rs
@@ -1,0 +1,166 @@
+//! # WASM Module Cache Strategy Picker
+//!
+//! Compiling a WASM module is expensive (~ 100 ms / MiB on M1). Caching
+//! options: in-memory (fast, lost on tab close), IndexedDB (persistent
+//! across sessions), Cache API (HTTP-backed, sw-friendly), none
+//! (always recompile). This recipe picks the strategy by size + use
+//! case.
+//!
+//! Demonstrates the **WASM.8** recipe for PMAT-123 (wasm coverage).
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml
+//! Citation: WICG WebAssembly Compile-Streams + Cache API conventions
+//!
+//! Run with: cargo run --example wasm_module_cache_strategy
+//!
+//! Added by PMAT-123 (expand-cookbooks followup).
+
+use apr_cookbook::recipe::RecipeContext;
+use apr_cookbook::Result;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CacheStrategy {
+    None,
+    InMemory,
+    IndexedDb,
+    CacheApi,
+}
+
+#[derive(Debug, PartialEq)]
+pub enum PickerVerdict {
+    Ok(CacheStrategy),
+    InvalidSize,
+}
+
+const TINY_MIB: u32 = 1;
+const SMALL_MIB: u32 = 10;
+const MEDIUM_MIB: u32 = 100;
+
+pub fn pick(module_size_mib: u32, persistent: bool, http_backed: bool) -> PickerVerdict {
+    if module_size_mib == 0 {
+        return PickerVerdict::InvalidSize;
+    }
+    // For tiny modules, recompile beats cache lookup overhead.
+    if module_size_mib <= TINY_MIB && !persistent {
+        return PickerVerdict::Ok(CacheStrategy::None);
+    }
+    if http_backed {
+        return PickerVerdict::Ok(CacheStrategy::CacheApi);
+    }
+    if persistent {
+        return PickerVerdict::Ok(CacheStrategy::IndexedDb);
+    }
+    if module_size_mib <= SMALL_MIB {
+        PickerVerdict::Ok(CacheStrategy::InMemory)
+    } else if module_size_mib <= MEDIUM_MIB {
+        PickerVerdict::Ok(CacheStrategy::IndexedDb)
+    } else {
+        // Large modules: persist via IndexedDB regardless.
+        PickerVerdict::Ok(CacheStrategy::IndexedDb)
+    }
+}
+
+pub fn estimated_compile_ms(module_size_mib: u32) -> u64 {
+    // Rough heuristic: 100 ms / MiB.
+    u64::from(module_size_mib) * 100
+}
+
+fn main() -> Result<()> {
+    let _ctx = RecipeContext::new("wasm_module_cache_strategy")?;
+
+    let cases = [
+        (1, false, false),
+        (5, false, false),
+        (50, false, false),
+        (200, true, false),
+        (5, false, true),
+    ];
+    for (mib, persistent, http) in cases {
+        println!(
+            "{mib} MiB persistent={persistent} http={http}  →  {:?}",
+            pick(mib, persistent, http)
+        );
+    }
+    println!("compile(50 MiB) = {} ms", estimated_compile_ms(50));
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn picker_runs() {
+        main().expect("recipe execution failed");
+    }
+
+    #[test]
+    fn tiny_non_persistent_uses_none() {
+        assert_eq!(
+            pick(1, false, false),
+            PickerVerdict::Ok(CacheStrategy::None)
+        );
+    }
+
+    #[test]
+    fn small_non_persistent_uses_in_memory() {
+        assert_eq!(
+            pick(5, false, false),
+            PickerVerdict::Ok(CacheStrategy::InMemory)
+        );
+    }
+
+    #[test]
+    fn medium_non_persistent_uses_indexeddb() {
+        assert_eq!(
+            pick(50, false, false),
+            PickerVerdict::Ok(CacheStrategy::IndexedDb)
+        );
+    }
+
+    #[test]
+    fn large_uses_indexeddb_for_persistence() {
+        assert_eq!(
+            pick(200, false, false),
+            PickerVerdict::Ok(CacheStrategy::IndexedDb)
+        );
+    }
+
+    #[test]
+    fn http_backed_uses_cache_api() {
+        // HTTP source → service-worker-friendly Cache API.
+        assert_eq!(
+            pick(5, false, true),
+            PickerVerdict::Ok(CacheStrategy::CacheApi)
+        );
+    }
+
+    #[test]
+    fn explicit_persistent_overrides_in_memory() {
+        // 5 MiB normally goes in-memory, but if persistent requested → IndexedDB.
+        assert_eq!(
+            pick(5, true, false),
+            PickerVerdict::Ok(CacheStrategy::IndexedDb)
+        );
+    }
+
+    #[test]
+    fn zero_size_invalid() {
+        assert_eq!(pick(0, false, false), PickerVerdict::InvalidSize);
+    }
+
+    #[test]
+    fn compile_estimate_scales_with_size() {
+        assert_eq!(estimated_compile_ms(1), 100);
+        assert_eq!(estimated_compile_ms(10), 1000);
+    }
+
+    #[test]
+    fn http_takes_priority_over_persistent() {
+        // HTTP-backed is the strongest signal.
+        assert_eq!(
+            pick(50, true, true),
+            PickerVerdict::Ok(CacheStrategy::CacheApi)
+        );
+    }
+}


### PR DESCRIPTION
## Summary
**Second non-CLI batch.** Closes the apr speech F-invariant gap (1 → 4 recipes) and pads wasm + simd from 5/4 to 8/7.

- **3 speech recipes** — audio format magic-byte detector (WAV/FLAC/MP3), dBFS VAD threshold classifier + adaptive threshold, Whisper streaming chunk + overlap planner — **closes F-invariant gap**
- **3 wasm recipes** — linear-memory page envelope + 32/64-bit browser caps + growth strategy, capability classifier (SIMD128/threads/bulk-memory feature tiers), module cache strategy picker (None/InMemory/IndexedDB/CacheApi)
- **3 simd recipes** — SSE/AVX2/AVX512/NEON pointer alignment validator + load intrinsic recommender, loop unroll factor picker (vs register pressure), horizontal sum/min/max reduce dispatcher (log₂ tree depth)
- Wires 9 \`[[example]]\` entries; recipe catalog now **735** (was 726)
- All recipes follow IIUR template: pure function + Verdict enum + 9-12 tests + arXiv/standards citation, offline-only, RecipeContext-scoped

## Coverage Impact (F-Invariant: ≥3 recipes per surface)
| Surface | Before | After |
|---------|--------|-------|
| **speech** | **1 (gap)** | **4 (closed)** |
| wasm | 5 | 8 |
| simd | 4 | 7 |

## Test plan
- [x] cargo build --examples
- [x] cargo clippy --examples --tests -- -D warnings
- [x] All 9 recipe test suites pass (95 tests total)
- [x] cargo fmt
- [x] Pre-push hook (fmt + clippy + cargo test --all-features) green
- [ ] CI: cpu-gates / Quality Gate (admin-merge per documented playbook if cpu-gates green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)