### PR TITLE
feat(PMAT-134): simd + wasm + serverless expansion (9 recipes; catalog 825→834)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3621,3 +3621,41 @@ path = "examples/bundling/bundle_table_of_contents.rs"
 [[example]]
 name = "bundle_integrity_checksum"
 path = "examples/bundling/bundle_integrity_checksum.rs"
+
+# --- simd / wasm / serverless extension (PMAT-134 expand-cookbooks followup) ---
+
+[[example]]
+name = "simd_mask_lane_predicate"
+path = "examples/simd/simd_mask_lane_predicate.rs"
+
+[[example]]
+name = "simd_prefetch_distance_picker"
+path = "examples/simd/simd_prefetch_distance_picker.rs"
+
+[[example]]
+name = "simd_fma_fusion_gate"
+path = "examples/simd/simd_fma_fusion_gate.rs"
+
+[[example]]
+name = "wasm_threads_atomics_gate"
+path = "examples/wasm/wasm_threads_atomics_gate.rs"
+
+[[example]]
+name = "wasm_simd128_dispatch"
+path = "examples/wasm/wasm_simd128_dispatch.rs"
+
+[[example]]
+name = "wasm_wasi_capability_grant"
+path = "examples/wasm/wasm_wasi_capability_grant.rs"
+
+[[example]]
+name = "serverless_timeout_budget_picker"
+path = "examples/serverless/serverless_timeout_budget_picker.rs"
+
+[[example]]
+name = "serverless_provisioned_concurrency"
+path = "examples/serverless/serverless_provisioned_concurrency.rs"
+
+[[example]]
+name = "serverless_vpc_cold_start"
+path = "examples/serverless/serverless_vpc_cold_start.rs"

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ cargo run --example 2>&1 | head -50
 <!-- Re-generate: ./scripts/generate-recipe-table.sh --update -->
 <!-- CI validates: recipe-table workflow ensures this table matches source -->
 
-**825 recipes** | Build: [![CI](https://github.com/paiml/apr-cookbook/actions/workflows/ci.yml/badge.svg)](https://github.com/paiml/apr-cookbook/actions/workflows/ci.yml)
+**834 recipes** | Build: [![CI](https://github.com/paiml/apr-cookbook/actions/workflows/ci.yml/badge.svg)](https://github.com/paiml/apr-cookbook/actions/workflows/ci.yml)
 
 <details>
 <summary>Full recipe table (click to expand)</summary>
@@ -898,74 +898,83 @@ cargo run --example 2>&1 | head -50
 | 755 | `serverless_lambda_inference` | serverless | ![serverless](https://img.shields.io/badge/-serverless-yellow) | ✅ |
 | 756 | `serverless_lambda_pricing_matrix` | serverless | ![serverless](https://img.shields.io/badge/-serverless-yellow) | ✅ |
 | 757 | `serverless_model_warmup` | serverless | ![serverless](https://img.shields.io/badge/-serverless-yellow) | ✅ |
-| 758 | `shell_brace_expander` | shell | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
-| 759 | `shell_corpus_from_string` | shell | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
-| 760 | `shell_history_parse_zsh` | shell | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
-| 761 | `shell_pipe_redirection_parser` | shell | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
-| 762 | `shell_quote_state_classifier` | shell | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
-| 763 | `shell_trie_prefix_completion` | shell | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
-| 764 | `simd_alignment_validator` | simd | ![x86_64](https://img.shields.io/badge/-x86__64-blue) ![aarch64](https://img.shields.io/badge/-aarch64-blue) | ✅ |
-| 765 | `simd_auto_vectorization` | simd | ![x86_64](https://img.shields.io/badge/-x86__64-blue) | ✅ |
-| 766 | `simd_avx_vnni_int8_inference` | simd | ![x86_64](https://img.shields.io/badge/-x86__64-blue) ![aarch64](https://img.shields.io/badge/-aarch64-blue) | ✅ |
-| 767 | `simd_horizontal_reduce_dispatcher` | simd | ![x86_64](https://img.shields.io/badge/-x86__64-blue) | ✅ |
-| 768 | `simd_matrix_ops` | simd | ![x86_64](https://img.shields.io/badge/-x86__64-blue) ![aarch64](https://img.shields.io/badge/-aarch64-blue) | ✅ |
-| 769 | `simd_quantized_operations` | simd | ![x86_64](https://img.shields.io/badge/-x86__64-blue) | ✅ |
-| 770 | `simd_unroll_factor_picker` | simd | ![x86_64](https://img.shields.io/badge/-x86__64-blue) | ✅ |
-| 771 | `simd_vectorized_inference` | simd | ![x86_64](https://img.shields.io/badge/-x86__64-blue) | ✅ |
-| 772 | `trueno_simd_ops` | simd | ![x86_64](https://img.shields.io/badge/-x86__64-blue) ![aarch64](https://img.shields.io/badge/-aarch64-blue) | ✅ |
-| 773 | `speech_audio_format_validator` | speech | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
-| 774 | `speech_chunk_overlap_planner` | speech | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
-| 775 | `speech_diarization` | speech | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
-| 776 | `speech_multilingual` | speech | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
-| 777 | `speech_vad` | speech | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
-| 778 | `speech_vad_threshold_classifier` | speech | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
-| 779 | `whisper_streaming` | speech | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
-| 780 | `whisper_transcribe` | speech | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
-| 781 | `autograd_backprop_viz` | training | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
-| 782 | `autograd_custom_ops` | training | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
-| 783 | `autograd_gradient_clipping` | training | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
-| 784 | `checkpoint_resume` | training | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
-| 785 | `continuous_train_curriculum` | training | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
-| 786 | `continuous_train_federated_simulation` | training | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
-| 787 | `continuous_train_incremental` | training | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
-| 788 | `continuous_train_online_learning` | training | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
-| 789 | `data_preprocessing` | training | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
-| 790 | `data_sharded_shuffle` | training | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
-| 791 | `data_streaming_tokens` | training | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
-| 792 | `entrenar_autograd_training` | training | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
-| 793 | `entrenar_eval_metrics` | training | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
-| 794 | `few_shot_finetune` | training | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
-| 795 | `gradient_accumulation` | training | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
-| 796 | `hyperparameter_sweep` | training | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
-| 797 | `learning_rate_schedule` | training | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
-| 798 | `mixed_precision_training` | training | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
-| 799 | `pretrain_checkpoint_resume` | training | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
-| 800 | `pretrain_nan_guard` | training | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
-| 801 | `pretrain_synthetic_decreasing` | training | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
-| 802 | `train_distributed_sim` | training | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
-| 803 | `train_grad_accum` | training | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
-| 804 | `training_curriculum_filter` | training | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
-| 805 | `training_grad_clip_norm` | training | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
-| 806 | `training_lr_combo_scheduler` | training | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
-| 807 | `tsp_christofides_ratio` | tsp | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
-| 808 | `tsp_compare_tabu_vs_genetic` | tsp | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
-| 809 | `tsp_distance_matrix_explicit` | tsp | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
-| 810 | `tsp_nearest_neighbor` | tsp | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
-| 811 | `tsp_solve_with_tabu` | tsp | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
-| 812 | `tsp_two_opt_swap_improver` | tsp | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
-| 813 | `load_visualization` | visualization | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
-| 814 | `viz_axis_scale_classifier` | visualization | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
-| 815 | `viz_color_palette_picker` | visualization | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
-| 816 | `viz_legend_placement_optimizer` | visualization | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
-| 817 | `wasm_browser_inference` | wasm | ![wasm](https://img.shields.io/badge/-wasm-purple) | ✅ |
-| 818 | `wasm_capability_check` | wasm | ![wasm](https://img.shields.io/badge/-wasm-purple) | ✅ |
-| 819 | `wasm_memory_growth_policy` | wasm | ![wasm](https://img.shields.io/badge/-wasm-purple) | ✅ |
-| 820 | `wasm_model_loader` | wasm | ![wasm](https://img.shields.io/badge/-wasm-purple) | ✅ |
-| 821 | `wasm_module_cache_strategy` | wasm | ![wasm](https://img.shields.io/badge/-wasm-purple) | ✅ |
-| 822 | `wasm_progressive_loading` | wasm | ![wasm](https://img.shields.io/badge/-wasm-purple) | ✅ |
-| 823 | `wasm_streaming_compilation` | wasm | ![wasm](https://img.shields.io/badge/-wasm-purple) | ✅ |
-| 824 | `wasm_web_worker` | wasm | ![wasm](https://img.shields.io/badge/-wasm-purple) | ✅ |
-| 825 | `wasm_webgpu_acceleration` | wasm | ![wgpu](https://img.shields.io/badge/-wgpu-green) ![wasm](https://img.shields.io/badge/-wasm-purple) | ✅ |
+| 758 | `serverless_provisioned_concurrency` | serverless | ![serverless](https://img.shields.io/badge/-serverless-yellow) | ✅ |
+| 759 | `serverless_timeout_budget_picker` | serverless | ![serverless](https://img.shields.io/badge/-serverless-yellow) | ✅ |
+| 760 | `serverless_vpc_cold_start` | serverless | ![serverless](https://img.shields.io/badge/-serverless-yellow) | ✅ |
+| 761 | `shell_brace_expander` | shell | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
+| 762 | `shell_corpus_from_string` | shell | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
+| 763 | `shell_history_parse_zsh` | shell | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
+| 764 | `shell_pipe_redirection_parser` | shell | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
+| 765 | `shell_quote_state_classifier` | shell | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
+| 766 | `shell_trie_prefix_completion` | shell | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
+| 767 | `simd_alignment_validator` | simd | ![x86_64](https://img.shields.io/badge/-x86__64-blue) ![aarch64](https://img.shields.io/badge/-aarch64-blue) | ✅ |
+| 768 | `simd_auto_vectorization` | simd | ![x86_64](https://img.shields.io/badge/-x86__64-blue) | ✅ |
+| 769 | `simd_avx_vnni_int8_inference` | simd | ![x86_64](https://img.shields.io/badge/-x86__64-blue) ![aarch64](https://img.shields.io/badge/-aarch64-blue) | ✅ |
+| 770 | `simd_fma_fusion_gate` | simd | ![aarch64](https://img.shields.io/badge/-aarch64-blue) | ✅ |
+| 771 | `simd_horizontal_reduce_dispatcher` | simd | ![x86_64](https://img.shields.io/badge/-x86__64-blue) | ✅ |
+| 772 | `simd_mask_lane_predicate` | simd | ![x86_64](https://img.shields.io/badge/-x86__64-blue) | ✅ |
+| 773 | `simd_matrix_ops` | simd | ![x86_64](https://img.shields.io/badge/-x86__64-blue) ![aarch64](https://img.shields.io/badge/-aarch64-blue) | ✅ |
+| 774 | `simd_prefetch_distance_picker` | simd | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
+| 775 | `simd_quantized_operations` | simd | ![x86_64](https://img.shields.io/badge/-x86__64-blue) | ✅ |
+| 776 | `simd_unroll_factor_picker` | simd | ![x86_64](https://img.shields.io/badge/-x86__64-blue) | ✅ |
+| 777 | `simd_vectorized_inference` | simd | ![x86_64](https://img.shields.io/badge/-x86__64-blue) | ✅ |
+| 778 | `trueno_simd_ops` | simd | ![x86_64](https://img.shields.io/badge/-x86__64-blue) ![aarch64](https://img.shields.io/badge/-aarch64-blue) | ✅ |
+| 779 | `speech_audio_format_validator` | speech | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
+| 780 | `speech_chunk_overlap_planner` | speech | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
+| 781 | `speech_diarization` | speech | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
+| 782 | `speech_multilingual` | speech | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
+| 783 | `speech_vad` | speech | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
+| 784 | `speech_vad_threshold_classifier` | speech | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
+| 785 | `whisper_streaming` | speech | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
+| 786 | `whisper_transcribe` | speech | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
+| 787 | `autograd_backprop_viz` | training | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
+| 788 | `autograd_custom_ops` | training | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
+| 789 | `autograd_gradient_clipping` | training | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
+| 790 | `checkpoint_resume` | training | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
+| 791 | `continuous_train_curriculum` | training | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
+| 792 | `continuous_train_federated_simulation` | training | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
+| 793 | `continuous_train_incremental` | training | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
+| 794 | `continuous_train_online_learning` | training | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
+| 795 | `data_preprocessing` | training | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
+| 796 | `data_sharded_shuffle` | training | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
+| 797 | `data_streaming_tokens` | training | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
+| 798 | `entrenar_autograd_training` | training | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
+| 799 | `entrenar_eval_metrics` | training | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
+| 800 | `few_shot_finetune` | training | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
+| 801 | `gradient_accumulation` | training | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
+| 802 | `hyperparameter_sweep` | training | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
+| 803 | `learning_rate_schedule` | training | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
+| 804 | `mixed_precision_training` | training | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
+| 805 | `pretrain_checkpoint_resume` | training | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
+| 806 | `pretrain_nan_guard` | training | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
+| 807 | `pretrain_synthetic_decreasing` | training | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
+| 808 | `train_distributed_sim` | training | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
+| 809 | `train_grad_accum` | training | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
+| 810 | `training_curriculum_filter` | training | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
+| 811 | `training_grad_clip_norm` | training | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
+| 812 | `training_lr_combo_scheduler` | training | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
+| 813 | `tsp_christofides_ratio` | tsp | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
+| 814 | `tsp_compare_tabu_vs_genetic` | tsp | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
+| 815 | `tsp_distance_matrix_explicit` | tsp | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
+| 816 | `tsp_nearest_neighbor` | tsp | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
+| 817 | `tsp_solve_with_tabu` | tsp | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
+| 818 | `tsp_two_opt_swap_improver` | tsp | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
+| 819 | `load_visualization` | visualization | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
+| 820 | `viz_axis_scale_classifier` | visualization | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
+| 821 | `viz_color_palette_picker` | visualization | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
+| 822 | `viz_legend_placement_optimizer` | visualization | ![cpu](https://img.shields.io/badge/-cpu-lightgrey) | ✅ |
+| 823 | `wasm_browser_inference` | wasm | ![wasm](https://img.shields.io/badge/-wasm-purple) | ✅ |
+| 824 | `wasm_capability_check` | wasm | ![wasm](https://img.shields.io/badge/-wasm-purple) | ✅ |
+| 825 | `wasm_memory_growth_policy` | wasm | ![wasm](https://img.shields.io/badge/-wasm-purple) | ✅ |
+| 826 | `wasm_model_loader` | wasm | ![wasm](https://img.shields.io/badge/-wasm-purple) | ✅ |
+| 827 | `wasm_module_cache_strategy` | wasm | ![wasm](https://img.shields.io/badge/-wasm-purple) | ✅ |
+| 828 | `wasm_progressive_loading` | wasm | ![wasm](https://img.shields.io/badge/-wasm-purple) | ✅ |
+| 829 | `wasm_simd128_dispatch` | wasm | ![wasm](https://img.shields.io/badge/-wasm-purple) | ✅ |
+| 830 | `wasm_streaming_compilation` | wasm | ![wasm](https://img.shields.io/badge/-wasm-purple) | ✅ |
+| 831 | `wasm_threads_atomics_gate` | wasm | ![wasm](https://img.shields.io/badge/-wasm-purple) | ✅ |
+| 832 | `wasm_wasi_capability_grant` | wasm | ![wasm](https://img.shields.io/badge/-wasm-purple) | ✅ |
+| 833 | `wasm_web_worker` | wasm | ![wasm](https://img.shields.io/badge/-wasm-purple) | ✅ |
+| 834 | `wasm_webgpu_acceleration` | wasm | ![wgpu](https://img.shields.io/badge/-wgpu-green) ![wasm](https://img.shields.io/badge/-wasm-purple) | ✅ |
 
 </details>
 <!-- RECIPE-TABLE-END -->

--- a/examples/serverless/serverless_provisioned_concurrency.rs
+++ b/examples/serverless/serverless_provisioned_concurrency.rs
@@ -1,0 +1,176 @@
+//! # Serverless Provisioned Concurrency Calculator
+//!
+//! Provisioned concurrency = ceil(p99_qps × p99_duration_seconds × headroom).
+//! Too low = cold-start spikes; too high = $$ wasted on idle
+//! containers. Headroom 1.2-2.0× per AWS recs. This recipe builds the
+//! calculator.
+//!
+//! Demonstrates the **SVL.9** recipe for PMAT-134 (serverless coverage).
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml
+//! Citation: AWS Lambda provisioned concurrency calculator (Q4 2024 docs).
+//!
+//! Run with: cargo run --example serverless_provisioned_concurrency
+//!
+//! Added by PMAT-134 (expand-cookbooks followup).
+
+use apr_cookbook::recipe::RecipeContext;
+use apr_cookbook::Result;
+
+const MAX_RECOMMENDED_PC: u32 = 1000;
+
+#[derive(Debug, PartialEq)]
+pub enum PcVerdict {
+    Ok {
+        units: u32,
+        monthly_cost_estimate_usd: f64,
+    },
+    InvalidLoad,
+    InvalidHeadroom,
+    AboveSoftCap {
+        recommended: u32,
+    },
+}
+
+const PC_PRICE_USD_PER_GB_SECOND: f64 = 0.0000041;
+const SECONDS_PER_MONTH: f64 = 30.0 * 24.0 * 3600.0;
+
+pub fn calc(p99_qps: f64, mean_duration_secs: f64, headroom: f64, mem_gb: f64) -> PcVerdict {
+    if !p99_qps.is_finite() || p99_qps <= 0.0 {
+        return PcVerdict::InvalidLoad;
+    }
+    if !mean_duration_secs.is_finite() || mean_duration_secs <= 0.0 {
+        return PcVerdict::InvalidLoad;
+    }
+    if !headroom.is_finite() || headroom < 1.0 {
+        return PcVerdict::InvalidHeadroom;
+    }
+    if !mem_gb.is_finite() || mem_gb <= 0.0 {
+        return PcVerdict::InvalidLoad;
+    }
+    let raw = (p99_qps * mean_duration_secs * headroom).ceil() as u32;
+    let units = raw.max(1);
+    if units > MAX_RECOMMENDED_PC {
+        return PcVerdict::AboveSoftCap {
+            recommended: MAX_RECOMMENDED_PC,
+        };
+    }
+    let monthly = f64::from(units) * mem_gb * SECONDS_PER_MONTH * PC_PRICE_USD_PER_GB_SECOND;
+    PcVerdict::Ok {
+        units,
+        monthly_cost_estimate_usd: monthly,
+    }
+}
+
+fn main() -> Result<()> {
+    let _ctx = RecipeContext::new("serverless_provisioned_concurrency")?;
+
+    for (qps, dur, hr, mem) in [
+        (10.0_f64, 0.5_f64, 1.5_f64, 1.0_f64),
+        (100.0, 0.2, 2.0, 0.5),
+        (1000.0, 1.0, 1.5, 2.0),
+        (0.0, 0.5, 1.5, 1.0),
+        (10.0, 0.5, 0.5, 1.0),
+    ] {
+        println!(
+            "qps={qps} dur={dur}s headroom={hr} mem={mem}GiB → {:?}",
+            calc(qps, dur, hr, mem)
+        );
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn calc_runs() {
+        main().expect("recipe execution failed");
+    }
+
+    #[test]
+    fn typical_load_calculated() {
+        // 10 qps × 0.5s × 1.5 = 7.5 → ceil 8.
+        let v = calc(10.0, 0.5, 1.5, 1.0);
+        if let PcVerdict::Ok { units, .. } = v {
+            assert_eq!(units, 8);
+        }
+    }
+
+    #[test]
+    fn high_load_calculated() {
+        // 100 × 0.2 × 2.0 = 40.
+        let v = calc(100.0, 0.2, 2.0, 0.5);
+        if let PcVerdict::Ok { units, .. } = v {
+            assert_eq!(units, 40);
+        }
+    }
+
+    #[test]
+    fn extreme_load_capped() {
+        // 1000 × 1.0 × 1.5 = 1500 > 1000 cap.
+        let v = calc(1000.0, 1.0, 1.5, 2.0);
+        assert!(matches!(v, PcVerdict::AboveSoftCap { .. }));
+    }
+
+    #[test]
+    fn zero_qps_invalid() {
+        assert_eq!(calc(0.0, 0.5, 1.5, 1.0), PcVerdict::InvalidLoad);
+    }
+
+    #[test]
+    fn negative_duration_invalid() {
+        assert_eq!(calc(10.0, -0.1, 1.5, 1.0), PcVerdict::InvalidLoad);
+    }
+
+    #[test]
+    fn headroom_below_one_invalid() {
+        assert_eq!(calc(10.0, 0.5, 0.5, 1.0), PcVerdict::InvalidHeadroom);
+    }
+
+    #[test]
+    fn nan_input_invalid() {
+        assert_eq!(calc(f64::NAN, 0.5, 1.5, 1.0), PcVerdict::InvalidLoad);
+    }
+
+    #[test]
+    fn floor_at_one_unit_minimum() {
+        // 0.1 qps × 0.1s × 1.0 headroom = 0.01 → ceil 1.
+        let v = calc(0.1, 0.1, 1.0, 1.0);
+        if let PcVerdict::Ok { units, .. } = v {
+            assert_eq!(units, 1);
+        }
+    }
+
+    #[test]
+    fn cost_proportional_to_memory() {
+        let small = calc(10.0, 0.5, 1.5, 0.5);
+        let large = calc(10.0, 0.5, 1.5, 2.0);
+        if let (
+            PcVerdict::Ok {
+                monthly_cost_estimate_usd: c_small,
+                ..
+            },
+            PcVerdict::Ok {
+                monthly_cost_estimate_usd: c_large,
+                ..
+            },
+        ) = (small, large)
+        {
+            // 4× memory → 4× cost.
+            assert!((c_large / c_small - 4.0).abs() < 1e-6);
+        }
+    }
+
+    #[test]
+    fn cost_positive_for_valid_input() {
+        if let PcVerdict::Ok {
+            monthly_cost_estimate_usd,
+            ..
+        } = calc(10.0, 0.5, 1.5, 1.0)
+        {
+            assert!(monthly_cost_estimate_usd > 0.0);
+        }
+    }
+}

--- a/examples/serverless/serverless_timeout_budget_picker.rs
+++ b/examples/serverless/serverless_timeout_budget_picker.rs
@@ -1,0 +1,171 @@
+//! # Serverless Timeout Budget Picker
+//!
+//! Lambda timeouts: 1s/3s/15s/60s/15min. Pick the smallest tier where
+//! P99_inference + cold_start_ms + 200ms safety < tier. Too small =
+//! truncated requests; too large = wasted billing seconds. This recipe
+//! builds the picker.
+//!
+//! Demonstrates the **SVL.8** recipe for PMAT-134 (serverless coverage).
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml
+//! Citation: AWS Lambda execution-time pricing model.
+//!
+//! Run with: cargo run --example serverless_timeout_budget_picker
+//!
+//! Added by PMAT-134 (expand-cookbooks followup).
+
+use apr_cookbook::recipe::RecipeContext;
+use apr_cookbook::Result;
+
+const TIERS_MS: [u32; 5] = [1_000, 3_000, 15_000, 60_000, 900_000];
+const SAFETY_MARGIN_MS: u32 = 200;
+
+#[derive(Debug, PartialEq)]
+pub enum TimeoutVerdict {
+    Ok {
+        tier_ms: u32,
+        budget_ms: u32,
+        slack_ms: u32,
+    },
+    InvalidLatency,
+    NeedsHigherTier {
+        required_ms: u32,
+    },
+}
+
+pub fn pick(p99_inference_ms: u32, cold_start_ms: u32) -> TimeoutVerdict {
+    let total = p99_inference_ms
+        .checked_add(cold_start_ms)
+        .and_then(|x| x.checked_add(SAFETY_MARGIN_MS));
+    let Some(budget_ms) = total else {
+        return TimeoutVerdict::InvalidLatency;
+    };
+    if budget_ms == SAFETY_MARGIN_MS {
+        return TimeoutVerdict::InvalidLatency;
+    }
+    for &tier in &TIERS_MS {
+        if budget_ms <= tier {
+            return TimeoutVerdict::Ok {
+                tier_ms: tier,
+                budget_ms,
+                slack_ms: tier - budget_ms,
+            };
+        }
+    }
+    TimeoutVerdict::NeedsHigherTier {
+        required_ms: budget_ms,
+    }
+}
+
+fn main() -> Result<()> {
+    let _ctx = RecipeContext::new("serverless_timeout_budget_picker")?;
+
+    for (p99, cold) in [
+        (50u32, 200u32),
+        (500, 1500),
+        (5000, 2000),
+        (30000, 5000),
+        (1_000_000, 0),
+        (0, 0),
+    ] {
+        println!("p99={p99}ms cold={cold}ms → {:?}", pick(p99, cold));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn picker_runs() {
+        main().expect("recipe execution failed");
+    }
+
+    #[test]
+    fn fast_inference_picks_one_second_tier() {
+        // 50 + 200 + 200 = 450 ≤ 1000.
+        let v = pick(50, 200);
+        assert!(matches!(v, TimeoutVerdict::Ok { tier_ms: 1_000, .. }));
+    }
+
+    #[test]
+    fn medium_picks_three_second_tier() {
+        // 500 + 1500 + 200 = 2200 ≤ 3000.
+        let v = pick(500, 1500);
+        assert!(matches!(v, TimeoutVerdict::Ok { tier_ms: 3_000, .. }));
+    }
+
+    #[test]
+    fn slow_picks_fifteen_second_tier() {
+        // 5000 + 2000 + 200 = 7200 ≤ 15000.
+        let v = pick(5000, 2000);
+        assert!(matches!(
+            v,
+            TimeoutVerdict::Ok {
+                tier_ms: 15_000,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn very_slow_picks_sixty_second_tier() {
+        // 30000 + 5000 + 200 = 35200 ≤ 60000.
+        let v = pick(30000, 5000);
+        assert!(matches!(
+            v,
+            TimeoutVerdict::Ok {
+                tier_ms: 60_000,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn excessive_picks_max_tier_or_overflow() {
+        // 200000 + 0 + 200 = 200200 ≤ 900000 (15 min tier).
+        let v = pick(200_000, 0);
+        assert!(matches!(
+            v,
+            TimeoutVerdict::Ok {
+                tier_ms: 900_000,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn beyond_lambda_max_needs_higher_tier() {
+        let v = pick(1_000_000, 0);
+        assert!(matches!(v, TimeoutVerdict::NeedsHigherTier { .. }));
+    }
+
+    #[test]
+    fn zero_budget_invalid() {
+        // 0 + 0 + 200 = 200 ms is just the safety margin → InvalidLatency.
+        assert_eq!(pick(0, 0), TimeoutVerdict::InvalidLatency);
+    }
+
+    #[test]
+    fn slack_correctly_computed() {
+        // 50 + 200 + 200 = 450; tier = 1000; slack = 550.
+        if let TimeoutVerdict::Ok { slack_ms, .. } = pick(50, 200) {
+            assert_eq!(slack_ms, 550);
+        }
+    }
+
+    #[test]
+    fn safety_margin_applied() {
+        // budget always includes 200 ms safety.
+        if let TimeoutVerdict::Ok { budget_ms, .. } = pick(100, 100) {
+            assert_eq!(budget_ms, 100 + 100 + 200);
+        }
+    }
+
+    #[test]
+    fn large_input_overflow_safe() {
+        // u32::MAX would overflow on add → InvalidLatency.
+        assert_eq!(pick(u32::MAX, 1000), TimeoutVerdict::InvalidLatency);
+    }
+}

--- a/examples/serverless/serverless_vpc_cold_start.rs
+++ b/examples/serverless/serverless_vpc_cold_start.rs
@@ -1,0 +1,216 @@
+//! # Serverless VPC Cold-Start Classifier
+//!
+//! Lambda in a VPC adds ENI (Elastic Network Interface) attachment time
+//! to cold start. Hyperplane (post-2019 redesign) made this go from
+//! ~10s to ~100ms but it still adds. Classify cold-start budget tier:
+//! Sub100Ms, Sub1Sec, Sub10Sec, AboveBudget. This recipe builds the
+//! classifier.
+//!
+//! Demonstrates the **SVL.10** recipe for PMAT-134 (serverless coverage).
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml
+//! Citation: AWS Lambda Hyperplane VPC networking redesign (re:Invent 2019).
+//!
+//! Run with: cargo run --example serverless_vpc_cold_start
+//!
+//! Added by PMAT-134 (expand-cookbooks followup).
+
+use apr_cookbook::recipe::RecipeContext;
+use apr_cookbook::Result;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ColdTier {
+    Sub100Ms,
+    Sub1Sec,
+    Sub10Sec,
+    AboveBudget,
+}
+
+#[derive(Debug, PartialEq)]
+pub enum ClassifyVerdict {
+    Ok {
+        tier: ColdTier,
+        total_cold_ms: u32,
+        eni_overhead_ms: u32,
+    },
+    InvalidConfig,
+}
+
+pub fn classify(
+    base_cold_start_ms: u32,
+    in_vpc: bool,
+    has_provisioned_concurrency: bool,
+) -> ClassifyVerdict {
+    if base_cold_start_ms == 0 && !has_provisioned_concurrency {
+        return ClassifyVerdict::InvalidConfig;
+    }
+    let eni = if in_vpc && !has_provisioned_concurrency {
+        100u32
+    } else {
+        0
+    };
+    let total = if has_provisioned_concurrency {
+        0
+    } else {
+        base_cold_start_ms.saturating_add(eni)
+    };
+    let tier = match total {
+        0..=100 => ColdTier::Sub100Ms,
+        101..=1000 => ColdTier::Sub1Sec,
+        1001..=10_000 => ColdTier::Sub10Sec,
+        _ => ColdTier::AboveBudget,
+    };
+    ClassifyVerdict::Ok {
+        tier,
+        total_cold_ms: total,
+        eni_overhead_ms: eni,
+    }
+}
+
+fn main() -> Result<()> {
+    let _ctx = RecipeContext::new("serverless_vpc_cold_start")?;
+
+    for (base, vpc, pc) in [
+        (50u32, false, false),
+        (50, true, false),
+        (500, true, false),
+        (5000, true, false),
+        (15000, true, false),
+        (5000, true, true),
+        (0, false, true),
+    ] {
+        println!(
+            "base={base}ms vpc={vpc} pc={pc} → {:?}",
+            classify(base, vpc, pc)
+        );
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn classify_runs() {
+        main().expect("recipe execution failed");
+    }
+
+    #[test]
+    fn fast_no_vpc_sub_100ms() {
+        let v = classify(50, false, false);
+        assert!(matches!(
+            v,
+            ClassifyVerdict::Ok {
+                tier: ColdTier::Sub100Ms,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn vpc_adds_eni_overhead() {
+        if let ClassifyVerdict::Ok {
+            eni_overhead_ms, ..
+        } = classify(50, true, false)
+        {
+            assert_eq!(eni_overhead_ms, 100);
+        }
+    }
+
+    #[test]
+    fn no_vpc_no_eni_overhead() {
+        if let ClassifyVerdict::Ok {
+            eni_overhead_ms, ..
+        } = classify(50, false, false)
+        {
+            assert_eq!(eni_overhead_ms, 0);
+        }
+    }
+
+    #[test]
+    fn slow_in_vpc_picks_sub_1sec() {
+        // 500 + 100 = 600 → Sub1Sec.
+        let v = classify(500, true, false);
+        assert!(matches!(
+            v,
+            ClassifyVerdict::Ok {
+                tier: ColdTier::Sub1Sec,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn very_slow_in_vpc_picks_sub_10sec() {
+        // 5000 + 100 = 5100 → Sub10Sec.
+        let v = classify(5000, true, false);
+        assert!(matches!(
+            v,
+            ClassifyVerdict::Ok {
+                tier: ColdTier::Sub10Sec,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn enormous_above_budget() {
+        let v = classify(15000, true, false);
+        assert!(matches!(
+            v,
+            ClassifyVerdict::Ok {
+                tier: ColdTier::AboveBudget,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn provisioned_concurrency_zeroes_cold() {
+        if let ClassifyVerdict::Ok { total_cold_ms, .. } = classify(5000, true, true) {
+            assert_eq!(total_cold_ms, 0);
+        }
+    }
+
+    #[test]
+    fn provisioned_concurrency_picks_sub_100ms() {
+        let v = classify(5000, true, true);
+        assert!(matches!(
+            v,
+            ClassifyVerdict::Ok {
+                tier: ColdTier::Sub100Ms,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn zero_base_no_pc_invalid() {
+        assert_eq!(classify(0, false, false), ClassifyVerdict::InvalidConfig);
+    }
+
+    #[test]
+    fn provisioned_concurrency_eni_zero_too() {
+        // PC also bypasses ENI overhead.
+        if let ClassifyVerdict::Ok {
+            eni_overhead_ms, ..
+        } = classify(0, true, true)
+        {
+            assert_eq!(eni_overhead_ms, 0);
+        }
+    }
+
+    #[test]
+    fn boundary_at_100ms_is_sub_100ms() {
+        // 0 + 100 ENI = 100 → Sub100Ms (inclusive).
+        let v = classify(0, true, true);
+        assert!(matches!(
+            v,
+            ClassifyVerdict::Ok {
+                tier: ColdTier::Sub100Ms,
+                ..
+            }
+        ));
+    }
+}

--- a/examples/simd/simd_fma_fusion_gate.rs
+++ b/examples/simd/simd_fma_fusion_gate.rs
@@ -1,0 +1,199 @@
+//! # SIMD FMA Fusion Eligibility Gate
+//!
+//! `a * b + c` can be fused into a single `fmadd` instruction (one
+//! rounding step, lower latency) only when:
+//! - the target CPU supports the relevant FMA ISA (FMA3/FMA4/NEON-FMA),
+//! - the precision is f32/f64 (no fused half on most CPUs),
+//! - strict-rounding is not required by the user (fmadd has 1 round
+//!   instead of mul-then-add 2 rounds).
+//!
+//! This recipe builds the gate.
+//!
+//! Demonstrates the **SIMD.11** recipe for PMAT-134 (simd coverage).
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml
+//! Citation: IEEE 754-2008 fused multiply-add definition.
+//!
+//! Run with: cargo run --example simd_fma_fusion_gate
+//!
+//! Added by PMAT-134 (expand-cookbooks followup).
+
+use apr_cookbook::recipe::RecipeContext;
+use apr_cookbook::Result;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CpuIsa {
+    Fma3,
+    Fma4,
+    NeonFma,
+    NoFma,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Precision {
+    F16,
+    F32,
+    F64,
+}
+
+#[derive(Debug, PartialEq)]
+pub enum FuseVerdict {
+    Fuse,
+    Skip { reason: SkipReason },
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum SkipReason {
+    NoIsaSupport,
+    StrictRoundingRequired,
+    UnsupportedHalfPrecision,
+}
+
+pub fn decide(isa: CpuIsa, precision: Precision, strict_rounding: bool) -> FuseVerdict {
+    if strict_rounding {
+        return FuseVerdict::Skip {
+            reason: SkipReason::StrictRoundingRequired,
+        };
+    }
+    if isa == CpuIsa::NoFma {
+        return FuseVerdict::Skip {
+            reason: SkipReason::NoIsaSupport,
+        };
+    }
+    if precision == Precision::F16 {
+        return FuseVerdict::Skip {
+            reason: SkipReason::UnsupportedHalfPrecision,
+        };
+    }
+    FuseVerdict::Fuse
+}
+
+fn main() -> Result<()> {
+    let _ctx = RecipeContext::new("simd_fma_fusion_gate")?;
+
+    let cases = [
+        (CpuIsa::Fma3, Precision::F32, false),
+        (CpuIsa::Fma3, Precision::F32, true),
+        (CpuIsa::NoFma, Precision::F32, false),
+        (CpuIsa::Fma3, Precision::F16, false),
+        (CpuIsa::NeonFma, Precision::F64, false),
+    ];
+    for (isa, prec, strict) in cases {
+        println!(
+            "{isa:?} / {prec:?} / strict={strict} → {:?}",
+            decide(isa, prec, strict)
+        );
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn gate_runs() {
+        main().expect("recipe execution failed");
+    }
+
+    #[test]
+    fn fma3_f32_default_fuses() {
+        assert_eq!(
+            decide(CpuIsa::Fma3, Precision::F32, false),
+            FuseVerdict::Fuse
+        );
+    }
+
+    #[test]
+    fn fma3_f64_fuses() {
+        assert_eq!(
+            decide(CpuIsa::Fma3, Precision::F64, false),
+            FuseVerdict::Fuse
+        );
+    }
+
+    #[test]
+    fn neon_fuses() {
+        assert_eq!(
+            decide(CpuIsa::NeonFma, Precision::F32, false),
+            FuseVerdict::Fuse
+        );
+    }
+
+    #[test]
+    fn no_isa_skipped() {
+        let v = decide(CpuIsa::NoFma, Precision::F32, false);
+        assert_eq!(
+            v,
+            FuseVerdict::Skip {
+                reason: SkipReason::NoIsaSupport
+            }
+        );
+    }
+
+    #[test]
+    fn strict_rounding_skipped() {
+        let v = decide(CpuIsa::Fma3, Precision::F32, true);
+        assert_eq!(
+            v,
+            FuseVerdict::Skip {
+                reason: SkipReason::StrictRoundingRequired
+            }
+        );
+    }
+
+    #[test]
+    fn half_precision_skipped() {
+        let v = decide(CpuIsa::Fma3, Precision::F16, false);
+        assert_eq!(
+            v,
+            FuseVerdict::Skip {
+                reason: SkipReason::UnsupportedHalfPrecision
+            }
+        );
+    }
+
+    #[test]
+    fn strict_rounding_takes_precedence_over_isa() {
+        // Strict-rounding requirement is checked first → skipped even on
+        // capable CPU.
+        let v = decide(CpuIsa::Fma4, Precision::F32, true);
+        assert_eq!(
+            v,
+            FuseVerdict::Skip {
+                reason: SkipReason::StrictRoundingRequired
+            }
+        );
+    }
+
+    #[test]
+    fn fma4_f64_fuses() {
+        assert_eq!(
+            decide(CpuIsa::Fma4, Precision::F64, false),
+            FuseVerdict::Fuse
+        );
+    }
+
+    #[test]
+    fn no_fma_with_strict_strict_wins() {
+        // Strict reason reported even when there's also no ISA.
+        let v = decide(CpuIsa::NoFma, Precision::F32, true);
+        assert_eq!(
+            v,
+            FuseVerdict::Skip {
+                reason: SkipReason::StrictRoundingRequired
+            }
+        );
+    }
+
+    #[test]
+    fn neon_f16_skipped() {
+        let v = decide(CpuIsa::NeonFma, Precision::F16, false);
+        assert_eq!(
+            v,
+            FuseVerdict::Skip {
+                reason: SkipReason::UnsupportedHalfPrecision
+            }
+        );
+    }
+}

--- a/examples/simd/simd_mask_lane_predicate.rs
+++ b/examples/simd/simd_mask_lane_predicate.rs
@@ -1,0 +1,182 @@
+//! # SIMD Mask Lane Predicate
+//!
+//! Predicated SIMD load/store: only lanes with mask=1 read/write
+//! memory. Used for tail-handling (last partial vector at the end of a
+//! tensor). This recipe builds the mask generator + the per-lane apply.
+//!
+//! Demonstrates the **SIMD.9** recipe for PMAT-134 (simd coverage).
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml
+//! Citation: AVX-512 vector mask register `kN` semantics; ARM SVE `pred`.
+//!
+//! Run with: cargo run --example simd_mask_lane_predicate
+//!
+//! Added by PMAT-134 (expand-cookbooks followup).
+
+use apr_cookbook::recipe::RecipeContext;
+use apr_cookbook::Result;
+
+const MAX_LANES: usize = 16;
+
+#[derive(Debug, PartialEq)]
+pub enum MaskVerdict {
+    Ok { mask: u16, active_lanes: u32 },
+    LaneCountTooHigh { lanes: usize },
+    PrefixWiderThanLanes { prefix: usize, lanes: usize },
+}
+
+pub fn prefix_mask(active_prefix: usize, total_lanes: usize) -> MaskVerdict {
+    if total_lanes == 0 || total_lanes > MAX_LANES {
+        return MaskVerdict::LaneCountTooHigh { lanes: total_lanes };
+    }
+    if active_prefix > total_lanes {
+        return MaskVerdict::PrefixWiderThanLanes {
+            prefix: active_prefix,
+            lanes: total_lanes,
+        };
+    }
+    let mask = if active_prefix == 0 {
+        0u16
+    } else {
+        ((1u32 << active_prefix) - 1) as u16
+    };
+    MaskVerdict::Ok {
+        mask,
+        active_lanes: active_prefix as u32,
+    }
+}
+
+pub fn apply_mask(values: &[f32], mask: u16) -> Vec<f32> {
+    values
+        .iter()
+        .enumerate()
+        .map(|(i, v)| if (mask >> i) & 1 == 1 { *v } else { 0.0 })
+        .collect()
+}
+
+pub fn tail_lanes_for(total_elems: usize, lane_width: usize) -> usize {
+    if lane_width == 0 {
+        return 0;
+    }
+    total_elems % lane_width
+}
+
+fn main() -> Result<()> {
+    let _ctx = RecipeContext::new("simd_mask_lane_predicate")?;
+
+    println!("prefix=4 of 8: {:?}", prefix_mask(4, 8));
+    println!("prefix=8 of 8 (full): {:?}", prefix_mask(8, 8));
+    println!("prefix=0: {:?}", prefix_mask(0, 8));
+    println!("invalid prefix>lanes: {:?}", prefix_mask(9, 8));
+
+    let v = [1.0f32, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0];
+    if let MaskVerdict::Ok { mask, .. } = prefix_mask(5, 8) {
+        println!("apply mask 0b11111: {:?}", apply_mask(&v, mask));
+    }
+
+    println!("tail of 130 elems / lane 16: {}", tail_lanes_for(130, 16));
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn predicate_runs() {
+        main().expect("recipe execution failed");
+    }
+
+    #[test]
+    fn full_prefix_all_ones() {
+        let v = prefix_mask(8, 8);
+        assert!(matches!(
+            v,
+            MaskVerdict::Ok {
+                mask: 0xFF,
+                active_lanes: 8
+            }
+        ));
+    }
+
+    #[test]
+    fn empty_prefix_zero_mask() {
+        let v = prefix_mask(0, 8);
+        assert!(matches!(
+            v,
+            MaskVerdict::Ok {
+                mask: 0,
+                active_lanes: 0
+            }
+        ));
+    }
+
+    #[test]
+    fn partial_prefix_sets_low_bits() {
+        let v = prefix_mask(4, 8);
+        assert!(matches!(
+            v,
+            MaskVerdict::Ok {
+                mask: 0b1111,
+                active_lanes: 4
+            }
+        ));
+    }
+
+    #[test]
+    fn prefix_wider_than_lanes_rejected() {
+        assert_eq!(
+            prefix_mask(9, 8),
+            MaskVerdict::PrefixWiderThanLanes {
+                prefix: 9,
+                lanes: 8
+            }
+        );
+    }
+
+    #[test]
+    fn lane_count_zero_rejected() {
+        assert_eq!(
+            prefix_mask(0, 0),
+            MaskVerdict::LaneCountTooHigh { lanes: 0 }
+        );
+    }
+
+    #[test]
+    fn lane_count_above_max_rejected() {
+        assert_eq!(
+            prefix_mask(0, 17),
+            MaskVerdict::LaneCountTooHigh { lanes: 17 }
+        );
+    }
+
+    #[test]
+    fn apply_mask_zeroes_inactive_lanes() {
+        let v = [1.0f32, 2.0, 3.0, 4.0];
+        let out = apply_mask(&v, 0b0011);
+        assert_eq!(out, vec![1.0, 2.0, 0.0, 0.0]);
+    }
+
+    #[test]
+    fn apply_full_mask_passes_through() {
+        let v = [1.0f32, 2.0, 3.0, 4.0];
+        let out = apply_mask(&v, 0b1111);
+        assert_eq!(out, vec![1.0, 2.0, 3.0, 4.0]);
+    }
+
+    #[test]
+    fn tail_lanes_typical() {
+        // 130 elems / 16-wide = 8 full vectors + 2 tail.
+        assert_eq!(tail_lanes_for(130, 16), 2);
+    }
+
+    #[test]
+    fn tail_lanes_evenly_divisible_zero() {
+        assert_eq!(tail_lanes_for(128, 16), 0);
+    }
+
+    #[test]
+    fn tail_lanes_zero_lane_width_safe() {
+        assert_eq!(tail_lanes_for(100, 0), 0);
+    }
+}

--- a/examples/simd/simd_prefetch_distance_picker.rs
+++ b/examples/simd/simd_prefetch_distance_picker.rs
@@ -1,0 +1,180 @@
+//! # SIMD Software Prefetch Distance Picker
+//!
+//! Streaming SIMD inference benefits from `prefetch` instructions
+//! issued some lookahead bytes ahead of the current load. Distance:
+//! too short = miss not hidden; too far = pollutes cache. Heuristic:
+//! distance = mem_latency_cycles × bytes_per_cycle, rounded to a
+//! cache-line multiple. This recipe builds the picker.
+//!
+//! Demonstrates the **SIMD.10** recipe for PMAT-134 (simd coverage).
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml
+//! Citation: Intel optimization manual § software prefetch tuning.
+//!
+//! Run with: cargo run --example simd_prefetch_distance_picker
+//!
+//! Added by PMAT-134 (expand-cookbooks followup).
+
+use apr_cookbook::recipe::RecipeContext;
+use apr_cookbook::Result;
+
+const CACHE_LINE_BYTES: u32 = 64;
+const MAX_DISTANCE_BYTES: u32 = 8 * 1024;
+
+#[derive(Debug, PartialEq)]
+pub enum PrefetchVerdict {
+    Ok {
+        distance_bytes: u32,
+        cache_lines: u32,
+    },
+    InvalidLatency,
+    InvalidBandwidth,
+    AboveMaxDistance {
+        recommended: u32,
+    },
+}
+
+pub fn pick(mem_latency_cycles: u32, bytes_per_cycle: u32) -> PrefetchVerdict {
+    if mem_latency_cycles == 0 {
+        return PrefetchVerdict::InvalidLatency;
+    }
+    if bytes_per_cycle == 0 {
+        return PrefetchVerdict::InvalidBandwidth;
+    }
+    let raw = mem_latency_cycles.saturating_mul(bytes_per_cycle);
+    let aligned = raw.div_ceil(CACHE_LINE_BYTES) * CACHE_LINE_BYTES;
+    if aligned > MAX_DISTANCE_BYTES {
+        return PrefetchVerdict::AboveMaxDistance {
+            recommended: MAX_DISTANCE_BYTES,
+        };
+    }
+    PrefetchVerdict::Ok {
+        distance_bytes: aligned,
+        cache_lines: aligned / CACHE_LINE_BYTES,
+    }
+}
+
+fn main() -> Result<()> {
+    let _ctx = RecipeContext::new("simd_prefetch_distance_picker")?;
+
+    let cases = [
+        (200u32, 16u32), // 3200 → 3200 (50 cache lines)
+        (50, 16),        // 800 → 832 (13 cache lines)
+        (200, 100),      // 20000 → capped
+        (0, 16),
+        (200, 0),
+    ];
+    for (lat, bw) in cases {
+        println!("lat={lat}c bw={bw}b/c → {:?}", pick(lat, bw));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn picker_runs() {
+        main().expect("recipe execution failed");
+    }
+
+    #[test]
+    fn typical_distance_aligned_to_cache_line() {
+        // 50 cycles × 16 bytes/cycle = 800 → ceil to 64-byte boundary = 832.
+        let v = pick(50, 16);
+        assert!(matches!(
+            v,
+            PrefetchVerdict::Ok {
+                distance_bytes: 832,
+                cache_lines: 13
+            }
+        ));
+    }
+
+    #[test]
+    fn already_aligned_passes_through() {
+        // 200 × 16 = 3200, exactly 50 cache lines.
+        let v = pick(200, 16);
+        assert!(matches!(
+            v,
+            PrefetchVerdict::Ok {
+                distance_bytes: 3200,
+                cache_lines: 50
+            }
+        ));
+    }
+
+    #[test]
+    fn excessive_distance_capped() {
+        let v = pick(1000, 100);
+        assert!(matches!(v, PrefetchVerdict::AboveMaxDistance { .. }));
+    }
+
+    #[test]
+    fn zero_latency_invalid() {
+        assert_eq!(pick(0, 16), PrefetchVerdict::InvalidLatency);
+    }
+
+    #[test]
+    fn zero_bandwidth_invalid() {
+        assert_eq!(pick(50, 0), PrefetchVerdict::InvalidBandwidth);
+    }
+
+    #[test]
+    fn small_latency_min_distance_one_line() {
+        // 1 × 1 = 1 byte → ceil to 64 bytes = 1 cache line.
+        let v = pick(1, 1);
+        assert!(matches!(
+            v,
+            PrefetchVerdict::Ok {
+                distance_bytes: 64,
+                cache_lines: 1
+            }
+        ));
+    }
+
+    #[test]
+    fn distance_always_multiple_of_64() {
+        for (lat, bw) in [(7u32, 5u32), (13, 11), (97, 3)] {
+            if let PrefetchVerdict::Ok { distance_bytes, .. } = pick(lat, bw) {
+                assert_eq!(
+                    distance_bytes % CACHE_LINE_BYTES,
+                    0,
+                    "distance not aligned for ({lat},{bw})"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn cache_lines_match_distance() {
+        if let PrefetchVerdict::Ok {
+            distance_bytes,
+            cache_lines,
+        } = pick(100, 8)
+        {
+            assert_eq!(cache_lines, distance_bytes / CACHE_LINE_BYTES);
+        }
+    }
+
+    #[test]
+    fn at_max_passes() {
+        // 8192 / 16 = 512 cycles → exactly MAX_DISTANCE_BYTES.
+        let v = pick(512, 16);
+        assert!(matches!(
+            v,
+            PrefetchVerdict::Ok {
+                distance_bytes: 8192,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn just_above_max_capped() {
+        // 8193 → ceil 8256 (129 lines) > MAX.
+        let v = pick(513, 16);
+        assert!(matches!(v, PrefetchVerdict::AboveMaxDistance { .. }));
+    }
+}

--- a/examples/wasm/wasm_simd128_dispatch.rs
+++ b/examples/wasm/wasm_simd128_dispatch.rs
@@ -1,0 +1,212 @@
+//! # WASM SIMD128 Runtime Dispatch
+//!
+//! WebAssembly SIMD128 is a feature-test: not all browsers/runtimes
+//! enable it (Safari < 16.4, older mobile WebViews). Strategy:
+//! detect at module instantiation, compile a SIMD-using path or a
+//! scalar-fallback path, expose them under one symbol. This recipe
+//! builds the dispatch picker.
+//!
+//! Demonstrates the **WASM.12** recipe for PMAT-134 (wasm coverage).
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml
+//! Citation: WebAssembly fixed-width SIMD proposal (v8/v128).
+//!
+//! Run with: cargo run --example wasm_simd128_dispatch
+//!
+//! Added by PMAT-134 (expand-cookbooks followup).
+
+use apr_cookbook::recipe::RecipeContext;
+use apr_cookbook::Result;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DispatchPath {
+    Simd128,
+    Scalar,
+}
+
+#[derive(Debug, PartialEq)]
+pub enum DispatchVerdict {
+    Ok {
+        path: DispatchPath,
+        expected_speedup: f64,
+    },
+    BothPathsMissing,
+}
+
+pub struct RuntimeProbe {
+    pub simd128_available: bool,
+    pub workload_vectorizable: bool,
+    pub min_speedup_threshold: f64,
+}
+
+pub fn pick(probe: &RuntimeProbe, scalar_available: bool) -> DispatchVerdict {
+    if !scalar_available && !probe.simd128_available {
+        return DispatchVerdict::BothPathsMissing;
+    }
+    let want_simd = probe.simd128_available
+        && probe.workload_vectorizable
+        && probe.min_speedup_threshold >= 1.0;
+    let path = if want_simd && probe.simd128_available {
+        DispatchPath::Simd128
+    } else {
+        DispatchPath::Scalar
+    };
+    let expected_speedup = if path == DispatchPath::Simd128 {
+        4.0_f64.max(probe.min_speedup_threshold)
+    } else {
+        1.0
+    };
+    DispatchVerdict::Ok {
+        path,
+        expected_speedup,
+    }
+}
+
+fn main() -> Result<()> {
+    let _ctx = RecipeContext::new("wasm_simd128_dispatch")?;
+
+    let probe = RuntimeProbe {
+        simd128_available: true,
+        workload_vectorizable: true,
+        min_speedup_threshold: 2.0,
+    };
+    println!("simd path: {:?}", pick(&probe, true));
+
+    let no_simd = RuntimeProbe {
+        simd128_available: false,
+        ..probe
+    };
+    println!("scalar fallback: {:?}", pick(&no_simd, true));
+
+    let both_gone = RuntimeProbe {
+        simd128_available: false,
+        ..probe
+    };
+    println!("both missing: {:?}", pick(&both_gone, false));
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn probe(simd: bool, vec: bool) -> RuntimeProbe {
+        RuntimeProbe {
+            simd128_available: simd,
+            workload_vectorizable: vec,
+            min_speedup_threshold: 2.0,
+        }
+    }
+
+    #[test]
+    fn dispatch_runs() {
+        main().expect("recipe execution failed");
+    }
+
+    #[test]
+    fn full_capability_picks_simd() {
+        let v = pick(&probe(true, true), true);
+        assert!(matches!(
+            v,
+            DispatchVerdict::Ok {
+                path: DispatchPath::Simd128,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn missing_simd_falls_back_to_scalar() {
+        let v = pick(&probe(false, true), true);
+        assert!(matches!(
+            v,
+            DispatchVerdict::Ok {
+                path: DispatchPath::Scalar,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn non_vectorizable_picks_scalar() {
+        let v = pick(&probe(true, false), true);
+        assert!(matches!(
+            v,
+            DispatchVerdict::Ok {
+                path: DispatchPath::Scalar,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn both_missing_rejected() {
+        let v = pick(&probe(false, false), false);
+        assert_eq!(v, DispatchVerdict::BothPathsMissing);
+    }
+
+    #[test]
+    fn scalar_path_speedup_one() {
+        if let DispatchVerdict::Ok {
+            expected_speedup, ..
+        } = pick(&probe(false, true), true)
+        {
+            assert_eq!(expected_speedup, 1.0);
+        }
+    }
+
+    #[test]
+    fn simd_path_speedup_at_least_four() {
+        if let DispatchVerdict::Ok {
+            expected_speedup, ..
+        } = pick(&probe(true, true), true)
+        {
+            assert!(expected_speedup >= 4.0);
+        }
+    }
+
+    #[test]
+    fn high_threshold_overrides_default_speedup() {
+        let p = RuntimeProbe {
+            simd128_available: true,
+            workload_vectorizable: true,
+            min_speedup_threshold: 6.0,
+        };
+        if let DispatchVerdict::Ok {
+            expected_speedup, ..
+        } = pick(&p, true)
+        {
+            assert_eq!(expected_speedup, 6.0);
+        }
+    }
+
+    #[test]
+    fn threshold_below_one_skips_simd() {
+        let p = RuntimeProbe {
+            simd128_available: true,
+            workload_vectorizable: true,
+            min_speedup_threshold: 0.5,
+        };
+        let v = pick(&p, true);
+        assert!(matches!(
+            v,
+            DispatchVerdict::Ok {
+                path: DispatchPath::Scalar,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn simd_only_no_scalar_still_picks_simd() {
+        // No scalar fallback exists, but SIMD is available.
+        let v = pick(&probe(true, true), false);
+        assert!(matches!(
+            v,
+            DispatchVerdict::Ok {
+                path: DispatchPath::Simd128,
+                ..
+            }
+        ));
+    }
+}

--- a/examples/wasm/wasm_threads_atomics_gate.rs
+++ b/examples/wasm/wasm_threads_atomics_gate.rs
@@ -1,0 +1,193 @@
+//! # WASM Threads + Atomics Capability Gate
+//!
+//! Multi-threaded WASM requires three browser features simultaneously:
+//! `WebAssembly.Memory({ shared: true })`, the `atomics` proposal, and
+//! cross-origin isolation (`COOP+COEP` headers). Missing any → fall
+//! back to single-threaded. This recipe builds the gate.
+//!
+//! Demonstrates the **WASM.11** recipe for PMAT-134 (wasm coverage).
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml
+//! Citation: WebAssembly threads proposal; W3C cross-origin isolation spec.
+//!
+//! Run with: cargo run --example wasm_threads_atomics_gate
+//!
+//! Added by PMAT-134 (expand-cookbooks followup).
+
+use apr_cookbook::recipe::RecipeContext;
+use apr_cookbook::Result;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ThreadsCapability {
+    pub shared_memory: bool,
+    pub atomics: bool,
+    pub cross_origin_isolated: bool,
+}
+
+#[derive(Debug, PartialEq)]
+pub enum ThreadsVerdict {
+    Enabled { recommended_workers: u32 },
+    Disabled { missing: Vec<&'static str> },
+    InvalidWorkerCount,
+}
+
+pub fn decide(cap: ThreadsCapability, hardware_concurrency: u32) -> ThreadsVerdict {
+    if hardware_concurrency == 0 {
+        return ThreadsVerdict::InvalidWorkerCount;
+    }
+    let mut missing: Vec<&'static str> = Vec::new();
+    if !cap.shared_memory {
+        missing.push("shared_memory");
+    }
+    if !cap.atomics {
+        missing.push("atomics");
+    }
+    if !cap.cross_origin_isolated {
+        missing.push("cross_origin_isolated");
+    }
+    if !missing.is_empty() {
+        return ThreadsVerdict::Disabled { missing };
+    }
+    let recommended = hardware_concurrency.saturating_sub(1).max(1);
+    ThreadsVerdict::Enabled {
+        recommended_workers: recommended,
+    }
+}
+
+fn main() -> Result<()> {
+    let _ctx = RecipeContext::new("wasm_threads_atomics_gate")?;
+
+    let full = ThreadsCapability {
+        shared_memory: true,
+        atomics: true,
+        cross_origin_isolated: true,
+    };
+    println!("full caps, 8 cores: {:?}", decide(full, 8));
+
+    let no_coop = ThreadsCapability {
+        cross_origin_isolated: false,
+        ..full
+    };
+    println!("missing COOP: {:?}", decide(no_coop, 8));
+
+    let nothing = ThreadsCapability {
+        shared_memory: false,
+        atomics: false,
+        cross_origin_isolated: false,
+    };
+    println!("nothing: {:?}", decide(nothing, 8));
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn gate_runs() {
+        main().expect("recipe execution failed");
+    }
+
+    fn full() -> ThreadsCapability {
+        ThreadsCapability {
+            shared_memory: true,
+            atomics: true,
+            cross_origin_isolated: true,
+        }
+    }
+
+    #[test]
+    fn full_caps_enables_threads() {
+        let v = decide(full(), 8);
+        assert!(matches!(
+            v,
+            ThreadsVerdict::Enabled {
+                recommended_workers: 7
+            }
+        ));
+    }
+
+    #[test]
+    fn missing_shared_memory_disabled() {
+        let cap = ThreadsCapability {
+            shared_memory: false,
+            ..full()
+        };
+        if let ThreadsVerdict::Disabled { missing } = decide(cap, 8) {
+            assert!(missing.contains(&"shared_memory"));
+        }
+    }
+
+    #[test]
+    fn missing_atomics_disabled() {
+        let cap = ThreadsCapability {
+            atomics: false,
+            ..full()
+        };
+        if let ThreadsVerdict::Disabled { missing } = decide(cap, 8) {
+            assert!(missing.contains(&"atomics"));
+        }
+    }
+
+    #[test]
+    fn missing_coop_disabled() {
+        let cap = ThreadsCapability {
+            cross_origin_isolated: false,
+            ..full()
+        };
+        if let ThreadsVerdict::Disabled { missing } = decide(cap, 8) {
+            assert!(missing.contains(&"cross_origin_isolated"));
+        }
+    }
+
+    #[test]
+    fn nothing_lists_all_missing() {
+        let cap = ThreadsCapability {
+            shared_memory: false,
+            atomics: false,
+            cross_origin_isolated: false,
+        };
+        if let ThreadsVerdict::Disabled { missing } = decide(cap, 8) {
+            assert_eq!(missing.len(), 3);
+        }
+    }
+
+    #[test]
+    fn zero_concurrency_invalid() {
+        assert_eq!(decide(full(), 0), ThreadsVerdict::InvalidWorkerCount);
+    }
+
+    #[test]
+    fn single_core_recommends_one_worker() {
+        // 1 - 1 = 0, but we floor at 1.
+        let v = decide(full(), 1);
+        assert!(matches!(
+            v,
+            ThreadsVerdict::Enabled {
+                recommended_workers: 1
+            }
+        ));
+    }
+
+    #[test]
+    fn high_concurrency_recommends_n_minus_one() {
+        let v = decide(full(), 32);
+        assert!(matches!(
+            v,
+            ThreadsVerdict::Enabled {
+                recommended_workers: 31
+            }
+        ));
+    }
+
+    #[test]
+    fn dual_core_recommends_one_worker() {
+        let v = decide(full(), 2);
+        assert!(matches!(
+            v,
+            ThreadsVerdict::Enabled {
+                recommended_workers: 1
+            }
+        ));
+    }
+}

--- a/examples/wasm/wasm_wasi_capability_grant.rs
+++ b/examples/wasm/wasm_wasi_capability_grant.rs
@@ -1,0 +1,160 @@
+//! # WASM WASI Capability Grant
+//!
+//! WASI-preview1 follows capability-based security: the host grants the
+//! guest a set of preopen FDs (filesystem dirs) and env vars; the guest
+//! can ONLY access those. This recipe builds the grant validator —
+//! reject paths outside preopens, normalize redundant slashes, and
+//! flag escape attempts (`..`).
+//!
+//! Demonstrates the **WASM.13** recipe for PMAT-134 (wasm coverage).
+//!
+//! Contract: contracts/recipe-iiur-v1.yaml
+//! Citation: WASI capability-based security model.
+//!
+//! Run with: cargo run --example wasm_wasi_capability_grant
+//!
+//! Added by PMAT-134 (expand-cookbooks followup).
+
+use apr_cookbook::recipe::RecipeContext;
+use apr_cookbook::Result;
+
+#[derive(Debug, PartialEq)]
+pub enum GrantVerdict {
+    Ok { canonical_path: String },
+    OutsidePreopens,
+    EscapeAttempt,
+    EmptyPreopens,
+    EmptyPath,
+}
+
+pub fn check(path: &str, preopens: &[&str]) -> GrantVerdict {
+    if path.is_empty() {
+        return GrantVerdict::EmptyPath;
+    }
+    if preopens.is_empty() {
+        return GrantVerdict::EmptyPreopens;
+    }
+    if path.split('/').any(|seg| seg == "..") {
+        return GrantVerdict::EscapeAttempt;
+    }
+    let canonical = canonicalize(path);
+    let granted = preopens
+        .iter()
+        .any(|p| canonical == *p || canonical.starts_with(&format!("{p}/")));
+    if !granted {
+        return GrantVerdict::OutsidePreopens;
+    }
+    GrantVerdict::Ok {
+        canonical_path: canonical,
+    }
+}
+
+fn canonicalize(path: &str) -> String {
+    let trimmed: String = path
+        .split('/')
+        .filter(|s| !s.is_empty() && *s != ".")
+        .collect::<Vec<_>>()
+        .join("/");
+    if path.starts_with('/') {
+        format!("/{trimmed}")
+    } else {
+        trimmed
+    }
+}
+
+fn main() -> Result<()> {
+    let _ctx = RecipeContext::new("wasm_wasi_capability_grant")?;
+
+    let preopens = ["/data/models", "/tmp"];
+    for p in [
+        "/data/models/llama.gguf",
+        "/data/models//x/y",
+        "/etc/passwd",
+        "/data/models/../../../etc/passwd",
+        "/tmp/scratch.bin",
+    ] {
+        println!("{p:<40}  →  {:?}", check(p, &preopens));
+    }
+    println!("empty path: {:?}", check("", &preopens));
+    println!("empty preopens: {:?}", check("/x", &[]));
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn grant_runs() {
+        main().expect("recipe execution failed");
+    }
+
+    #[test]
+    fn path_inside_preopen_granted() {
+        let v = check("/data/models/llama.gguf", &["/data/models"]);
+        assert!(matches!(v, GrantVerdict::Ok { .. }));
+    }
+
+    #[test]
+    fn path_outside_preopen_rejected() {
+        let v = check("/etc/passwd", &["/data/models"]);
+        assert_eq!(v, GrantVerdict::OutsidePreopens);
+    }
+
+    #[test]
+    fn escape_attempt_rejected() {
+        let v = check("/data/models/../../../etc/passwd", &["/data/models"]);
+        assert_eq!(v, GrantVerdict::EscapeAttempt);
+    }
+
+    #[test]
+    fn empty_path_rejected() {
+        assert_eq!(check("", &["/data"]), GrantVerdict::EmptyPath);
+    }
+
+    #[test]
+    fn empty_preopens_rejected() {
+        assert_eq!(check("/x", &[]), GrantVerdict::EmptyPreopens);
+    }
+
+    #[test]
+    fn redundant_slashes_normalized() {
+        let v = check("/data/models//x/y", &["/data/models"]);
+        if let GrantVerdict::Ok { canonical_path } = v {
+            assert_eq!(canonical_path, "/data/models/x/y");
+        }
+    }
+
+    #[test]
+    fn current_dir_dot_normalized_away() {
+        let v = check("/data/models/./x", &["/data/models"]);
+        if let GrantVerdict::Ok { canonical_path } = v {
+            assert_eq!(canonical_path, "/data/models/x");
+        }
+    }
+
+    #[test]
+    fn second_preopen_reachable() {
+        let v = check("/tmp/scratch.bin", &["/data/models", "/tmp"]);
+        assert!(matches!(v, GrantVerdict::Ok { .. }));
+    }
+
+    #[test]
+    fn exact_preopen_root_granted() {
+        let v = check("/data/models", &["/data/models"]);
+        assert!(matches!(v, GrantVerdict::Ok { .. }));
+    }
+
+    #[test]
+    fn similar_prefix_not_substring_match() {
+        // "/data/models2" should NOT be granted just because preopen is "/data/models".
+        let v = check("/data/models2/x", &["/data/models"]);
+        assert_eq!(v, GrantVerdict::OutsidePreopens);
+    }
+
+    #[test]
+    fn dotdot_anywhere_in_path_rejected() {
+        let v = check("/data/foo/../bar", &["/data"]);
+        assert_eq!(v, GrantVerdict::EscapeAttempt);
+    }
+}


### PR DESCRIPTION
## Summary
- Adds 9 IIUR-compliant recipes covering 3 non-CLI surfaces: simd (3), wasm (3), serverless (3)
- Catalog: **825 → 834** (+9 recipes, regenerated via \`scripts/generate-recipe-table.sh --update\`)
- Each recipe ships a \`Verdict\` enum, IIUR doc header, arXiv/spec citation, and 9-12 unit tests

## Coverage

| Surface | New recipes |
|---|---|
| simd | mask_lane_predicate (tail-handling), prefetch_distance_picker (cache-line aligned lookahead), fma_fusion_gate (FMA3/FMA4/NEON eligibility) |
| wasm | threads_atomics_gate (shared-mem + COOP/COEP), simd128_dispatch (runtime detect + scalar fallback), wasi_capability_grant (preopen-FD allowlist) |
| serverless | timeout_budget_picker (Lambda 5-tier picker), provisioned_concurrency (qps×duration×headroom + cost), vpc_cold_start (Sub100Ms..AboveBudget classifier) |

## Test plan
- [x] \`cargo build --examples\` clean
- [x] \`cargo clippy --examples -- -D warnings\` clean
- [x] \`cargo test --example <each>\` — 100 unit tests across 9 examples, all passing
- [x] \`cargo fmt --all\` applied
- [x] Recipe table regenerated (834 recipes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)