### PR TITLE
feat: PMAT-309/310 architecture-demos v1.1 — detector + summary meta-recipes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7162,3 +7162,12 @@ path = "examples/inference/inference_qwen3_5_smoke.rs"
 name = "inference_rwkv7_smoke"
 path = "examples/inference/inference_rwkv7_smoke.rs"
 
+# --- architecture-demos v1.1 (PMAT-309) ---
+
+[[example]]
+name = "inference_arch_detector"
+path = "examples/inference/inference_arch_detector.rs"
+
+[[example]]
+name = "inference_arch_summary"
+path = "examples/inference/inference_arch_summary.rs"

--- a/contracts/inference-arch-detector-v1.yaml
+++ b/contracts/inference-arch-detector-v1.yaml
@@ -1,0 +1,155 @@
+metadata:
+  version: "1.0.0"
+  created: "2026-05-07"
+  author: "PAIML Engineering"
+  description: "Architecture detector — discriminator-based dispatch from config.json to family identifier"
+  references:
+    - "docs/specifications/architecture-demos.md"
+    - "docs/specifications/architecture-demos/coverage-matrix.md (per-family discriminator catalog)"
+  depends_on:
+    - "recipe-iiur-v1"
+  tags:
+    - architecture-demos
+    - inference
+    - detector
+    - dispatch
+
+kernel_structure:
+  phases:
+    - name: setup
+      description: "Construct RecipeContext; resolve fixture path"
+      invariant: "context.temp_dir empty; fixture path readable"
+    - name: load
+      description: "Read config.json body as a string"
+      invariant: "Body is valid UTF-8"
+    - name: dispatch
+      description: "Pattern-match discriminator fields in priority order to identify family"
+      invariant: "Most-specific discriminator wins (qwen3_5 before qwen3 before qwen2; mistral before llama catch-all)"
+    - name: verify
+      description: "Two consecutive detect() calls produce equal verdicts"
+      invariant: "Detection is deterministic per-input"
+    - name: teardown
+      description: "Drop RecipeContext"
+      invariant: "context.temp_dir cleaned up"
+
+equations:
+  detector_dispatch:
+    formula: "detect(fixture) ↦ Family(name) | UnknownFamily | InvalidFixture"
+    domain: "fixture: Path"
+    codomain: "DetectorVerdict"
+    invariants:
+      - "Detect is total: every input produces some Verdict (no panic)"
+      - "Family ∈ {16 in-progress + 2 speech} = 18 supported families"
+      - "Order-sensitive dispatch: qwen3_5 before qwen3; mistral before llama; mamba before bert"
+    preconditions:
+      - "fixture is a valid UTF-8 path string"
+    postconditions:
+      - "match Family { name } => name ∈ {18 known families}"
+      - "match UnknownFamily { config_excerpt } => excerpt.len() ≤ 120"
+    lean_theorem: "Theorems.ArchDetector.Dispatch"
+    tolerance: 0
+    lean:
+      theorem: "Theorems.ArchDetector.Dispatch"
+      status: wip
+      module: "lean/Theorems/ArchDetector.lean"
+
+  discriminator_specificity:
+    formula: "more-specific discriminators dominate less-specific catch-alls"
+    domain: "config: String"
+    codomain: "DetectedFamily"
+    invariants:
+      - "Qwen3.5 fixture (has tie_word_embeddings + head_dim + qwen3_5) is detected as Qwen3_5, not Qwen3"
+      - "Mistral fixture (has sliding_window) is detected as Mistral, not Llama"
+      - "MAMBA fixture (state_size, no num_attention_heads) is detected as Mamba, not Bert"
+    preconditions:
+      - "config is non-empty"
+    postconditions:
+      - "Detection respects the per-family discriminator priority order"
+    lean_theorem: "Theorems.ArchDetector.Specificity"
+    tolerance: 0
+    lean:
+      theorem: "Theorems.ArchDetector.Specificity"
+      status: wip
+      module: "lean/Theorems/ArchDetector.lean"
+
+  determinism:
+    formula: "detect(f) == detect(f) for all f"
+    domain: "f: Path"
+    codomain: "DetectorVerdict"
+    invariants:
+      - "Detection is a pure function of input config bytes"
+    preconditions:
+      - "f is readable"
+    postconditions:
+      - "Two consecutive calls produce byte-equal verdicts"
+    lean_theorem: "Theorems.ArchDetector.Determinism"
+    tolerance: 0
+    lean:
+      theorem: "Theorems.ArchDetector.Determinism"
+      status: wip
+      module: "lean/Theorems/ArchDetector.lean"
+
+proof_obligations:
+  - type: invariant
+    property: "Detector dispatch is total"
+    formal: "for all fixture: Path. detect(fixture) ↦ DetectorVerdict (no panic)"
+    tolerance: 0.0
+    applies_to: detector_dispatch
+    lean:
+      theorem: "Theorems.ArchDetector.Dispatch"
+      module: "ProvableContracts.ArchitectureDemos.ArchDetector"
+  - type: invariant
+    property: "Discriminator priority is correct"
+    formal: "specific-fixture detected as specific-family, not generic catch-all"
+    tolerance: 0.0
+    applies_to: discriminator_specificity
+    lean:
+      theorem: "Theorems.ArchDetector.Specificity"
+      module: "ProvableContracts.ArchitectureDemos.ArchDetector"
+  - type: invariant
+    property: "Detection is deterministic"
+    formal: "detect(f) == detect(f)"
+    tolerance: 0.0
+    applies_to: determinism
+    lean:
+      theorem: "Theorems.ArchDetector.Determinism"
+      module: "ProvableContracts.ArchitectureDemos.ArchDetector"
+
+falsification_tests:
+  - id: FALSIFY-DETECTOR-001
+    rule: "Each of the 16 in-progress family fixtures detects to its own family"
+    prediction: "detect(fixtures/llama/config.json) ↦ Family { Llama, .. }; same for all 15 others"
+    test: "cargo test --example inference_arch_detector -- detects_"
+    if_fails: "Discriminator catalog drifted from one or more family recipes"
+  - id: FALSIFY-DETECTOR-002
+    rule: "Specificity priority — Qwen3.5 NOT classified as Qwen3"
+    prediction: "Qwen3.5 fixture detects as Qwen3_5 (more specific match wins)"
+    test: "cargo test --example inference_arch_detector -- detects_qwen3_5"
+    if_fails: "Dispatch order broke; less-specific match shadowed the specific one"
+  - id: FALSIFY-DETECTOR-003
+    rule: "Detector is total — unknown configs return UnknownFamily, never panic"
+    prediction: "Body without recognizable discriminators returns DetectorVerdict::UnknownFamily"
+    test: "cargo test --example inference_arch_detector -- unknown_config_returns_unknown_family"
+    if_fails: "Catch-all fallback removed; detector now panics or silently misclassifies"
+
+kani_harnesses:
+  - id: KANI-DETECTOR-001
+    obligation: "Detection is total"
+    bound: 4
+    strategy: bounded_int
+    harness: "kani_harnesses::arch_detector_total"
+  - id: KANI-DETECTOR-002
+    obligation: "Detection is deterministic"
+    bound: 4
+    strategy: bounded_int
+    harness: "kani_harnesses::arch_detector_deterministic"
+
+qa_gate:
+  id: F-DETECTOR-001
+  name: "Architecture Detector Contract"
+  description: "Cross-family discriminator-based dispatch from config.json to family identifier"
+  checks:
+    - "all_16_fixtures_detected"
+    - "specificity_priority_holds"
+    - "detection_is_total"
+  pass_criteria: "All three falsification tests pass; 16/16 fixtures correctly classified"

--- a/contracts/inference-arch-summary-v1.yaml
+++ b/contracts/inference-arch-summary-v1.yaml
@@ -1,0 +1,153 @@
+metadata:
+  version: "1.0.0"
+  created: "2026-05-07"
+  author: "PAIML Engineering"
+  description: "Architecture summary — discriminator catalog across all 16 families with deterministic output"
+  references:
+    - "docs/specifications/architecture-demos.md"
+    - "docs/specifications/architecture-demos/coverage-matrix.md"
+  depends_on:
+    - "recipe-iiur-v1"
+  tags:
+    - architecture-demos
+    - inference
+    - summary
+    - documentation
+
+kernel_structure:
+  phases:
+    - name: setup
+      description: "Construct RecipeContext"
+      invariant: "context.temp_dir empty"
+    - name: load
+      description: "Walk all 16 family fixture configs and read their bodies"
+      invariant: "Every family in FAMILIES list has a corresponding fixture path"
+    - name: extract
+      description: "For each family, extract its discriminator field value"
+      invariant: "Each entry has nonempty family + discriminator_field strings"
+    - name: verify
+      description: "Two consecutive summarize() calls produce equal verdicts"
+      invariant: "Output is deterministic across runs"
+    - name: teardown
+      description: "Drop RecipeContext"
+      invariant: "context.temp_dir cleaned up"
+
+equations:
+  summary_total:
+    formula: "summarize() ↦ Ok { entries.len() == 16 } | InvalidFixture"
+    domain: "()"
+    codomain: "SummaryVerdict"
+    invariants:
+      - "Total: every invocation produces some Verdict (no panic)"
+      - "Ok arm has exactly 16 entries (matches the 16 in-progress families)"
+    preconditions:
+      - "All 16 fixture config.json files exist on disk"
+    postconditions:
+      - "match Ok { entries } => entries.len() == 16"
+      - "All entries have non-empty family + discriminator_field"
+    lean_theorem: "Theorems.ArchSummary.Total"
+    tolerance: 0
+    lean:
+      theorem: "Theorems.ArchSummary.Total"
+      status: wip
+      module: "lean/Theorems/ArchSummary.lean"
+
+  discriminator_uniqueness:
+    formula: "discriminator_field is unique per family except llama+qwen2 share rope_theta"
+    domain: "()"
+    codomain: "Vec<String>"
+    invariants:
+      - "16 families, 15 distinct discriminator fields (llama and qwen2 share rope_theta)"
+    preconditions:
+      - "All 16 family fixtures load successfully"
+    postconditions:
+      - "Distinct discriminator_field values count == 15"
+    lean_theorem: "Theorems.ArchSummary.DiscriminatorUniqueness"
+    tolerance: 0
+    lean:
+      theorem: "Theorems.ArchSummary.DiscriminatorUniqueness"
+      status: wip
+      module: "lean/Theorems/ArchSummary.lean"
+
+  determinism:
+    formula: "summarize() == summarize()"
+    domain: "()"
+    codomain: "SummaryVerdict"
+    invariants:
+      - "Output order is fixed by the FAMILIES const ordering"
+    preconditions:
+      - "Fixtures don't change between calls"
+    postconditions:
+      - "Two consecutive calls produce byte-equal verdicts"
+      - "First entry is always llama; last is always bert"
+    lean_theorem: "Theorems.ArchSummary.Determinism"
+    tolerance: 0
+    lean:
+      theorem: "Theorems.ArchSummary.Determinism"
+      status: wip
+      module: "lean/Theorems/ArchSummary.lean"
+
+proof_obligations:
+  - type: invariant
+    property: "Summary produces exactly 16 entries"
+    formal: "summarize().entries.len() == 16"
+    tolerance: 0.0
+    applies_to: summary_total
+    lean:
+      theorem: "Theorems.ArchSummary.Total"
+      module: "ProvableContracts.ArchitectureDemos.ArchSummary"
+  - type: invariant
+    property: "15 distinct discriminator fields across 16 families"
+    formal: "unique(discriminator_field).len() == 15"
+    tolerance: 0.0
+    applies_to: discriminator_uniqueness
+    lean:
+      theorem: "Theorems.ArchSummary.DiscriminatorUniqueness"
+      module: "ProvableContracts.ArchitectureDemos.ArchSummary"
+  - type: invariant
+    property: "Output is deterministic"
+    formal: "summarize() == summarize()"
+    tolerance: 0.0
+    applies_to: determinism
+    lean:
+      theorem: "Theorems.ArchSummary.Determinism"
+      module: "ProvableContracts.ArchitectureDemos.ArchSummary"
+
+falsification_tests:
+  - id: FALSIFY-SUMMARY-001
+    rule: "Summary returns 16 entries (one per in-progress family)"
+    prediction: "summarize() ↦ Ok with entries.len() == 16"
+    test: "cargo test --example inference_arch_summary -- all_16_families_returned"
+    if_fails: "FAMILIES const drifted from manifest's 16 in-progress entries"
+  - id: FALSIFY-SUMMARY-002
+    rule: "15 unique discriminators across 16 families (llama+qwen2 share rope_theta)"
+    prediction: "Distinct discriminator_field values count == 15"
+    test: "cargo test --example inference_arch_summary -- discriminators_unique_across_families"
+    if_fails: "Discriminator catalog drifted; either too many shared or all unique"
+  - id: FALSIFY-SUMMARY-003
+    rule: "Output is deterministic across runs"
+    prediction: "Two summarize() invocations produce byte-equal output"
+    test: "cargo test --example inference_arch_summary -- deterministic_across_runs"
+    if_fails: "Non-determinism leaked from filesystem timestamps or RNG"
+
+kani_harnesses:
+  - id: KANI-SUMMARY-001
+    obligation: "Summary always returns 16 entries"
+    bound: 4
+    strategy: bounded_int
+    harness: "kani_harnesses::arch_summary_count"
+  - id: KANI-SUMMARY-002
+    obligation: "Summary is deterministic"
+    bound: 4
+    strategy: bounded_int
+    harness: "kani_harnesses::arch_summary_deterministic"
+
+qa_gate:
+  id: F-SUMMARY-001
+  name: "Architecture Summary Contract"
+  description: "Discriminator catalog across all 16 in-progress families with deterministic output"
+  checks:
+    - "all_16_families_returned"
+    - "discriminator_uniqueness"
+    - "deterministic_across_runs"
+  pass_criteria: "All three falsification tests pass"

--- a/examples/inference/inference_arch_detector.rs
+++ b/examples/inference/inference_arch_detector.rs
@@ -1,0 +1,424 @@
+//! # Architecture Detector — Cross-Family Discriminator Dispatch
+//!
+//! Take any HF `config.json` and identify which architecture family it
+//! belongs to by inspecting the **discriminator fields** each individual
+//! family recipe surfaces (`rope_theta`, `head_dim`, `tie_word_embeddings`,
+//! `qkv_proj_fused`, `query_pre_attn_scalar`, `n_embd`, `use_parallel_residual`,
+//! `n_routed_experts`, `mamba_d_state`, `time_mix_extra_dim`,
+//! `do_layer_norm_before`, `state_size`, `type_vocab_size`,
+//! `ffn_multipliers`, `sliding_window`).
+//!
+//! Demonstrates the **ARCH-DETECTOR** recipe per
+//! `docs/specifications/architecture-demos.md` v1.1.
+//!
+//! Mirrors the dispatch logic that upstream `aprender::rosetta::detect_family_from_config`
+//! could adopt: pattern-match the config's distinguishing fields against
+//! the 16 per-family discriminators that the architecture-demos manifest
+//! enumerates.
+//!
+//! IIUR Contract: contracts/recipe-iiur-v1.yaml
+//! Provable-contract: contracts/inference-arch-detector-v1.yaml (grade C; lean_status: wip)
+//! Citation: HuggingFace Transformers `config.json` schema; family-discriminator catalog from architecture-demos.md
+//!
+//! Run with: cargo run --example inference_arch_detector
+//!
+//! Added by PMAT-309 (architecture-demos v1.1: cross-family detector).
+
+use apr_cookbook::recipe::RecipeContext;
+use apr_cookbook::Result;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DetectedFamily {
+    Llama,
+    Mistral,
+    Qwen2,
+    Qwen3,
+    Qwen3_5,
+    Phi,
+    Gemma,
+    Gpt2,
+    GptNeox,
+    Deepseek,
+    FalconH1,
+    Rwkv7,
+    Openelm,
+    Opt,
+    Mamba,
+    Bert,
+    Whisper,
+    Moonshine,
+}
+
+impl DetectedFamily {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Llama => "llama",
+            Self::Mistral => "mistral",
+            Self::Qwen2 => "qwen2",
+            Self::Qwen3 => "qwen3",
+            Self::Qwen3_5 => "qwen3_5",
+            Self::Phi => "phi",
+            Self::Gemma => "gemma",
+            Self::Gpt2 => "gpt2",
+            Self::GptNeox => "gptneox",
+            Self::Deepseek => "deepseek",
+            Self::FalconH1 => "falcon_h1",
+            Self::Rwkv7 => "rwkv7",
+            Self::Openelm => "openelm",
+            Self::Opt => "opt",
+            Self::Mamba => "mamba",
+            Self::Bert => "bert",
+            Self::Whisper => "whisper",
+            Self::Moonshine => "moonshine",
+        }
+    }
+}
+
+#[derive(Debug, PartialEq)]
+pub enum DetectorVerdict {
+    Family {
+        family: DetectedFamily,
+        match_reason: String,
+    },
+    UnknownFamily {
+        config_excerpt: String,
+    },
+    InvalidFixture,
+}
+
+pub fn detect(fixture_path: &str) -> DetectorVerdict {
+    if !std::path::Path::new(fixture_path).exists() {
+        return DetectorVerdict::InvalidFixture;
+    }
+    let Ok(body) = std::fs::read_to_string(fixture_path) else {
+        return DetectorVerdict::InvalidFixture;
+    };
+    detect_from_str(&body)
+}
+
+/// Order matters: more-specific discriminators first. e.g., qwen3_5 has
+/// tie_word_embeddings AND head_dim, so it must be checked before qwen3.
+pub fn detect_from_str(body: &str) -> DetectorVerdict {
+    // Qwen3.5: explicit tie_word_embeddings + head_dim (extends Qwen3)
+    if body.contains("tie_word_embeddings") && body.contains("head_dim") && body.contains("qwen3_5")
+    {
+        return ok(
+            DetectedFamily::Qwen3_5,
+            "tie_word_embeddings + head_dim + qwen3_5",
+        );
+    }
+    // Qwen3: head_dim explicit, no tie_word_embeddings
+    if body.contains("head_dim") && body.contains("qwen3") && !body.contains("qwen3_5") {
+        return ok(DetectedFamily::Qwen3, "head_dim + qwen3");
+    }
+    // Qwen2: rope_theta=1000000 + qwen2 model_type, OR qkv biases pattern
+    if body.contains("qwen2") && body.contains("rope_theta") {
+        return ok(
+            DetectedFamily::Qwen2,
+            "qwen2 model_type + rope_theta=1000000",
+        );
+    }
+    // Phi: qkv_proj_fused field
+    if body.contains("qkv_proj_fused") {
+        return ok(DetectedFamily::Phi, "qkv_proj_fused field present");
+    }
+    // Gemma: query_pre_attn_scalar
+    if body.contains("query_pre_attn_scalar") {
+        return ok(DetectedFamily::Gemma, "query_pre_attn_scalar field present");
+    }
+    // GPT-NeoX: use_parallel_residual
+    if body.contains("use_parallel_residual") {
+        return ok(
+            DetectedFamily::GptNeox,
+            "use_parallel_residual field present",
+        );
+    }
+    // OPT: do_layer_norm_before
+    if body.contains("do_layer_norm_before") {
+        return ok(DetectedFamily::Opt, "do_layer_norm_before field present");
+    }
+    // GPT-2: n_embd short-name field
+    if body.contains("\"n_embd\"") {
+        return ok(DetectedFamily::Gpt2, "n_embd short-name field present");
+    }
+    // OpenELM: ffn_multipliers + num_query_heads arrays
+    if body.contains("ffn_multipliers") && body.contains("num_query_heads") {
+        return ok(
+            DetectedFamily::Openelm,
+            "ffn_multipliers + num_query_heads arrays",
+        );
+    }
+    // DeepSeek: n_routed_experts MoE field
+    if body.contains("n_routed_experts") {
+        return ok(DetectedFamily::Deepseek, "n_routed_experts MoE field");
+    }
+    // Falcon-H1: mamba_d_state + mamba_expand (hybrid SSM)
+    if body.contains("mamba_d_state") && body.contains("mamba_expand") && body.contains("falcon_h1")
+    {
+        return ok(
+            DetectedFamily::FalconH1,
+            "mamba_d_state + mamba_expand + falcon_h1",
+        );
+    }
+    // RWKV-7: time_mix_extra_dim
+    if body.contains("time_mix_extra_dim") {
+        return ok(
+            DetectedFamily::Rwkv7,
+            "time_mix_extra_dim linear-attention field",
+        );
+    }
+    // MAMBA: state_size + conv_kernel (pure SSM, no transformer fields)
+    if body.contains("state_size")
+        && body.contains("conv_kernel")
+        && !body.contains("num_attention_heads")
+    {
+        return ok(
+            DetectedFamily::Mamba,
+            "state_size + conv_kernel without attention",
+        );
+    }
+    // BERT: type_vocab_size encoder-only
+    if body.contains("type_vocab_size") {
+        return ok(DetectedFamily::Bert, "type_vocab_size encoder-only field");
+    }
+    // Mistral: sliding_window field (without Qwen2's qwen2 marker)
+    if body.contains("sliding_window") && body.contains("MistralForCausalLM") {
+        return ok(
+            DetectedFamily::Mistral,
+            "sliding_window + MistralForCausalLM architecture",
+        );
+    }
+    // Whisper: WhisperForConditionalGeneration
+    if body.contains("WhisperForConditionalGeneration") {
+        return ok(
+            DetectedFamily::Whisper,
+            "WhisperForConditionalGeneration architecture",
+        );
+    }
+    // Moonshine: MoonshineForConditionalGeneration
+    if body.contains("MoonshineForConditionalGeneration") {
+        return ok(
+            DetectedFamily::Moonshine,
+            "MoonshineForConditionalGeneration architecture",
+        );
+    }
+    // Llama: LlamaForCausalLM as the catch-all for transformer configs that
+    // didn't match anything more specific. Must be checked LAST.
+    if body.contains("LlamaForCausalLM") || body.contains("\"model_type\": \"llama\"") {
+        return ok(
+            DetectedFamily::Llama,
+            "LlamaForCausalLM (catch-all transformer)",
+        );
+    }
+    DetectorVerdict::UnknownFamily {
+        config_excerpt: body.chars().take(120).collect(),
+    }
+}
+
+fn ok(family: DetectedFamily, reason: &str) -> DetectorVerdict {
+    DetectorVerdict::Family {
+        family,
+        match_reason: reason.to_string(),
+    }
+}
+
+fn main() -> Result<()> {
+    let _ctx = RecipeContext::new("inference_arch_detector")?;
+    for fam in [
+        "llama",
+        "mistral",
+        "qwen2",
+        "qwen3",
+        "qwen3_5",
+        "phi",
+        "gemma",
+        "gpt2",
+        "gptneox",
+        "deepseek",
+        "falcon_h1",
+        "rwkv7",
+        "openelm",
+        "opt",
+        "mamba",
+        "bert",
+    ] {
+        let path = format!("tests/fixtures/architectures/{fam}/config.json");
+        match detect(&path) {
+            DetectorVerdict::Family {
+                family,
+                match_reason,
+            } => {
+                println!("{fam:>12}: detected {} ({match_reason})", family.as_str());
+            }
+            other => println!("{fam:>12}: {other:?}"),
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fixture(family: &str) -> String {
+        format!("tests/fixtures/architectures/{family}/config.json")
+    }
+
+    fn detect_family(family: &str) -> Option<DetectedFamily> {
+        match detect(&fixture(family)) {
+            DetectorVerdict::Family { family, .. } => Some(family),
+            _ => None,
+        }
+    }
+
+    #[test]
+    fn detector_runs() {
+        main().expect("recipe execution failed");
+    }
+
+    #[test]
+    fn missing_fixture_returns_invalid() {
+        assert_eq!(detect("/no/such/path"), DetectorVerdict::InvalidFixture);
+    }
+
+    #[test]
+    fn unknown_config_returns_unknown_family() {
+        let body = r#"{"model_type": "unknown_arch"}"#;
+        assert!(matches!(
+            detect_from_str(body),
+            DetectorVerdict::UnknownFamily { .. }
+        ));
+    }
+
+    #[test]
+    fn detects_llama() {
+        assert_eq!(detect_family("llama"), Some(DetectedFamily::Llama));
+    }
+
+    #[test]
+    fn detects_mistral() {
+        assert_eq!(detect_family("mistral"), Some(DetectedFamily::Mistral));
+    }
+
+    #[test]
+    fn detects_qwen2() {
+        assert_eq!(detect_family("qwen2"), Some(DetectedFamily::Qwen2));
+    }
+
+    #[test]
+    fn detects_qwen3() {
+        assert_eq!(detect_family("qwen3"), Some(DetectedFamily::Qwen3));
+    }
+
+    #[test]
+    fn detects_qwen3_5() {
+        assert_eq!(detect_family("qwen3_5"), Some(DetectedFamily::Qwen3_5));
+    }
+
+    #[test]
+    fn detects_phi() {
+        assert_eq!(detect_family("phi"), Some(DetectedFamily::Phi));
+    }
+
+    #[test]
+    fn detects_gemma() {
+        assert_eq!(detect_family("gemma"), Some(DetectedFamily::Gemma));
+    }
+
+    #[test]
+    fn detects_gpt2() {
+        assert_eq!(detect_family("gpt2"), Some(DetectedFamily::Gpt2));
+    }
+
+    #[test]
+    fn detects_gptneox() {
+        assert_eq!(detect_family("gptneox"), Some(DetectedFamily::GptNeox));
+    }
+
+    #[test]
+    fn detects_deepseek() {
+        assert_eq!(detect_family("deepseek"), Some(DetectedFamily::Deepseek));
+    }
+
+    #[test]
+    fn detects_falcon_h1() {
+        assert_eq!(detect_family("falcon_h1"), Some(DetectedFamily::FalconH1));
+    }
+
+    #[test]
+    fn detects_rwkv7() {
+        assert_eq!(detect_family("rwkv7"), Some(DetectedFamily::Rwkv7));
+    }
+
+    #[test]
+    fn detects_openelm() {
+        assert_eq!(detect_family("openelm"), Some(DetectedFamily::Openelm));
+    }
+
+    #[test]
+    fn detects_opt() {
+        assert_eq!(detect_family("opt"), Some(DetectedFamily::Opt));
+    }
+
+    #[test]
+    fn detects_mamba() {
+        assert_eq!(detect_family("mamba"), Some(DetectedFamily::Mamba));
+    }
+
+    #[test]
+    fn detects_bert() {
+        assert_eq!(detect_family("bert"), Some(DetectedFamily::Bert));
+    }
+
+    #[test]
+    fn deterministic_across_runs() {
+        let a = detect(&fixture("llama"));
+        let b = detect(&fixture("llama"));
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn family_as_str_round_trip() {
+        for fam in [
+            DetectedFamily::Llama,
+            DetectedFamily::Mistral,
+            DetectedFamily::Qwen2,
+            DetectedFamily::Phi,
+            DetectedFamily::Bert,
+        ] {
+            assert!(!fam.as_str().is_empty());
+            assert!(!fam.as_str().contains(' '));
+        }
+    }
+
+    #[test]
+    fn match_reason_nonempty_for_each_family() {
+        for fam in [
+            "llama",
+            "mistral",
+            "qwen2",
+            "qwen3",
+            "qwen3_5",
+            "phi",
+            "gemma",
+            "gpt2",
+            "gptneox",
+            "deepseek",
+            "falcon_h1",
+            "rwkv7",
+            "openelm",
+            "opt",
+            "mamba",
+            "bert",
+        ] {
+            if let DetectorVerdict::Family { match_reason, .. } = detect(&fixture(fam)) {
+                assert!(
+                    !match_reason.is_empty(),
+                    "family {fam} has empty match_reason"
+                );
+            } else {
+                panic!("expected Family verdict for {fam}");
+            }
+        }
+    }
+}

--- a/examples/inference/inference_arch_summary.rs
+++ b/examples/inference/inference_arch_summary.rs
@@ -1,0 +1,212 @@
+//! # Architecture Summary — Discriminator Catalog Across All Families
+//!
+//! Walk every bundled `tests/fixtures/architectures/<family>/config.json`,
+//! extract the family-specific discriminator field for each, and emit a
+//! deterministic summary line per family. Useful as documentation: a
+//! single recipe whose output is the family-discriminator catalog.
+//!
+//! Demonstrates the **ARCH-SUMMARY** recipe per
+//! `docs/specifications/architecture-demos.md` v1.1.
+//!
+//! IIUR Contract: contracts/recipe-iiur-v1.yaml
+//! Provable-contract: contracts/inference-arch-summary-v1.yaml (grade C; lean_status: wip)
+//! Citation: docs/specifications/architecture-demos.md (per-family discriminator catalog)
+//!
+//! Run with: cargo run --example inference_arch_summary
+//!
+//! Added by PMAT-310 (architecture-demos v1.1: summary + compare).
+
+use apr_cookbook::recipe::RecipeContext;
+use apr_cookbook::Result;
+
+#[derive(Debug, PartialEq)]
+pub struct FamilyEntry {
+    pub family: String,
+    pub discriminator_field: String,
+    pub discriminator_value: String,
+}
+
+#[derive(Debug, PartialEq)]
+pub enum SummaryVerdict {
+    Ok { entries: Vec<FamilyEntry> },
+    InvalidFixture { missing_family: String },
+}
+
+/// Per-family discriminator field. Mirrors what each family recipe surfaces
+/// in its `SmokeVerdict::Ok` arm.
+const FAMILIES: &[(&str, &str)] = &[
+    ("llama", "rope_theta"),
+    ("mistral", "sliding_window"),
+    ("qwen2", "rope_theta"),
+    ("qwen3", "head_dim"),
+    ("qwen3_5", "tie_word_embeddings"),
+    ("phi", "qkv_proj_fused"),
+    ("gemma", "query_pre_attn_scalar"),
+    ("gpt2", "n_embd"),
+    ("gptneox", "use_parallel_residual"),
+    ("deepseek", "n_routed_experts"),
+    ("falcon_h1", "mamba_d_state"),
+    ("rwkv7", "time_mix_extra_dim"),
+    ("openelm", "ffn_multipliers"),
+    ("opt", "do_layer_norm_before"),
+    ("mamba", "state_size"),
+    ("bert", "type_vocab_size"),
+];
+
+pub fn summarize() -> SummaryVerdict {
+    let mut entries: Vec<FamilyEntry> = Vec::with_capacity(FAMILIES.len());
+    for (family, field) in FAMILIES {
+        let path = format!("tests/fixtures/architectures/{family}/config.json");
+        let Ok(body) = std::fs::read_to_string(&path) else {
+            return SummaryVerdict::InvalidFixture {
+                missing_family: (*family).to_string(),
+            };
+        };
+        let value = extract_value(&body, field).unwrap_or_else(|| "(absent)".to_string());
+        entries.push(FamilyEntry {
+            family: (*family).to_string(),
+            discriminator_field: (*field).to_string(),
+            discriminator_value: value,
+        });
+    }
+    SummaryVerdict::Ok { entries }
+}
+
+/// Extract a discriminator value as a free-form string. For numbers and
+/// booleans, returns the literal token. For arrays, returns "(array)".
+fn extract_value(body: &str, key: &str) -> Option<String> {
+    let needle = format!("\"{key}\"");
+    let start = body.find(&needle)?;
+    let after_key = &body[start + needle.len()..];
+    let colon = after_key.find(':')?;
+    let rest = &after_key[colon + 1..].trim_start();
+    if rest.starts_with('[') {
+        return Some("(array)".to_string());
+    }
+    let end = rest.find([',', '}', '\n']).unwrap_or(rest.len());
+    Some(rest[..end].trim().to_string())
+}
+
+fn main() -> Result<()> {
+    let _ctx = RecipeContext::new("inference_arch_summary")?;
+    let v = summarize();
+    if let SummaryVerdict::Ok { entries } = &v {
+        println!(
+            "=== Architecture-Demos Discriminator Catalog ({} families) ===",
+            entries.len()
+        );
+        for e in entries {
+            println!(
+                "  {:>10}  {:>24} = {}",
+                e.family, e.discriminator_field, e.discriminator_value
+            );
+        }
+    } else {
+        println!("verdict: {v:?}");
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn summary_runs() {
+        main().expect("recipe execution failed");
+    }
+
+    #[test]
+    fn all_16_families_returned() {
+        if let SummaryVerdict::Ok { entries } = summarize() {
+            assert_eq!(entries.len(), 16);
+        } else {
+            panic!("expected Ok, got InvalidFixture");
+        }
+    }
+
+    #[test]
+    fn each_entry_has_nonempty_fields() {
+        if let SummaryVerdict::Ok { entries } = summarize() {
+            for e in entries {
+                assert!(!e.family.is_empty());
+                assert!(!e.discriminator_field.is_empty());
+                assert!(!e.discriminator_value.is_empty());
+            }
+        }
+    }
+
+    #[test]
+    fn deterministic_across_runs() {
+        let a = summarize();
+        let b = summarize();
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn families_unique_in_output() {
+        if let SummaryVerdict::Ok { entries } = summarize() {
+            let mut names: Vec<_> = entries.iter().map(|e| e.family.clone()).collect();
+            names.sort();
+            let n = names.len();
+            names.dedup();
+            assert_eq!(names.len(), n, "duplicate family in summary output");
+        }
+    }
+
+    #[test]
+    fn discriminators_unique_across_families() {
+        // Llama and Qwen2 share rope_theta — that's intentional. But every
+        // OTHER pair should be distinct: each family has its own
+        // discriminator field.
+        if let SummaryVerdict::Ok { entries } = summarize() {
+            let mut fields: Vec<_> = entries
+                .iter()
+                .map(|e| e.discriminator_field.clone())
+                .collect();
+            fields.sort();
+            // Expected: 16 entries, but llama+qwen2 share rope_theta so 15 unique.
+            fields.dedup();
+            assert_eq!(fields.len(), 15, "expected 15 distinct discriminators");
+        }
+    }
+
+    #[test]
+    fn extract_value_handles_int() {
+        let body = r#"{"head_dim": 16}"#;
+        assert_eq!(extract_value(body, "head_dim"), Some("16".to_string()));
+    }
+
+    #[test]
+    fn extract_value_handles_bool() {
+        let body = r#"{"qkv_proj_fused": true}"#;
+        assert_eq!(
+            extract_value(body, "qkv_proj_fused"),
+            Some("true".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_value_handles_array() {
+        let body = r#"{"ffn_multipliers": [0.5, 1.0]}"#;
+        assert_eq!(
+            extract_value(body, "ffn_multipliers"),
+            Some("(array)".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_value_handles_missing_key() {
+        let body = r#"{"other_key": 42}"#;
+        assert_eq!(extract_value(body, "missing"), None);
+    }
+
+    #[test]
+    fn output_format_is_stable() {
+        // Smoke: order matches FAMILIES const, so first entry is always llama.
+        if let SummaryVerdict::Ok { entries } = summarize() {
+            assert_eq!(entries[0].family, "llama");
+            assert_eq!(entries.last().unwrap().family, "bert");
+        }
+    }
+}

--- a/tests/contracts.rs
+++ b/tests/contracts.rs
@@ -29,7 +29,9 @@ const CONTRACT_FILES: &[&str] = &[
     "cli-parity-v1.yaml",
     "docs-schema-v1.yaml",
     "flash-attention-v1.yaml",
-    // architecture-demos (PMAT-300+): one per family.
+    // architecture-demos (PMAT-300+): one per family + cross-family detector (PMAT-309).
+    "inference-arch-detector-v1.yaml",
+    "inference-arch-summary-v1.yaml",
     "inference-bert-smoke-v1.yaml",
     "inference-deepseek-smoke-v1.yaml",
     "inference-falcon-h1-smoke-v1.yaml",


### PR DESCRIPTION
Stacked on #412. Two meta-recipes that operate ACROSS the 16 in-progress family fixtures, lifting architecture-demos from per-family-isolated to a unified system.

**PMAT-309 detector** (`examples/inference/inference_arch_detector.rs`): takes any HF `config.json` and identifies its family via discriminator-based dispatch in priority order. 22 tests. Mirrors what upstream `aprender::rosetta::detect_family_from_config` could adopt.

**PMAT-310 summary** (`examples/inference/inference_arch_summary.rs`): walks all 16 family fixtures and emits a deterministic discriminator catalog. 11 tests including 15-unique-discriminators-across-16-families (llama+qwen2 share `rope_theta`).

Both contracts: pv lint clean, score 0.65 Grade C, lean.status: wip. CONTRACT_FILES extended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)