### PR TITLE
feat: PMAT-313 architecture-demos v1.1 — upstream alias-resolver demo + cross-repo bridge

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7179,3 +7179,7 @@ path = "examples/inference/inference_arch_compare.rs"
 [[example]]
 name = "inference_arch_quirk_audit"
 path = "examples/inference/inference_arch_quirk_audit.rs"
+
+[[example]]
+name = "inference_arch_alias_resolver"
+path = "examples/inference/inference_arch_alias_resolver.rs"

--- a/contracts/inference-arch-alias-resolver-v1.yaml
+++ b/contracts/inference-arch-alias-resolver-v1.yaml
@@ -1,0 +1,155 @@
+metadata:
+  version: "1.0.0"
+  created: "2026-05-07"
+  author: "PAIML Engineering"
+  description: "Architecture alias resolver — HF-repo-pattern glob → parent family, demonstrating upstream aprender#1562 alias mechanism"
+  references:
+    - "https://github.com/paiml/aprender/pull/1562 (FamilyRegistry::register_alias upstream)"
+    - "docs/specifications/architecture-demos.md"
+    - "docs/specifications/architecture-demos/manifest.yaml (blocked-entries backlog)"
+  depends_on:
+    - "recipe-iiur-v1"
+  tags:
+    - architecture-demos
+    - inference
+    - alias
+    - upstream-bridge
+
+kernel_structure:
+  phases:
+    - name: setup
+      description: "Construct RecipeContext"
+      invariant: "context.temp_dir empty"
+    - name: lookup
+      description: "Iterate registered aliases in order; first match wins"
+      invariant: "ALIASES is a non-empty const slice of (pattern, parent) tuples"
+    - name: match
+      description: "Glob-match each pattern against the input HF repo identifier"
+      invariant: "Match logic mirrors upstream alias_matches: '*' is suffix wildcard"
+    - name: classify
+      description: "Map match outcome to AliasVerdict::Ok / NoMatch / InvalidInput"
+      invariant: "Empty input ↦ InvalidInput; no match ↦ NoMatch; otherwise Ok"
+    - name: teardown
+      description: "Drop RecipeContext"
+      invariant: "context.temp_dir cleaned up"
+
+equations:
+  alias_total:
+    formula: "resolve(repo) ↦ Ok | NoMatch | InvalidInput"
+    domain: "repo: &str"
+    codomain: "AliasVerdict"
+    invariants:
+      - "Total: every input produces some Verdict (no panic)"
+      - "Empty repo string ↦ InvalidInput"
+    preconditions:
+      - "repo is a valid UTF-8 string"
+    postconditions:
+      - "match Ok { resolved_family, .. } => resolved_family ∈ {18 supported families}"
+    lean_theorem: "Theorems.ArchAliasResolver.Total"
+    tolerance: 0
+    lean:
+      theorem: "Theorems.ArchAliasResolver.Total"
+      status: wip
+      module: "lean/Theorems/ArchAliasResolver.lean"
+
+  glob_semantics:
+    formula: "alias_matches(pattern, repo) holds iff pattern matches repo by * suffix wildcard"
+    domain: "pattern, repo: &str"
+    codomain: "bool"
+    invariants:
+      - "Pattern with trailing '*' matches any repo whose prefix equals pattern minus '*'"
+      - "Pattern without '*' requires exact repo equality"
+    preconditions:
+      - "pattern, repo are valid UTF-8"
+    postconditions:
+      - "alias_matches(\"codellama/*\", \"codellama/CodeLlama-7b-hf\") == true"
+      - "alias_matches(\"codellama/*\", \"meta-llama/Llama-3-8B\") == false"
+      - "alias_matches(\"distilbert/distilgpt2\", \"distilbert/distilgpt2\") == true"
+    lean_theorem: "Theorems.ArchAliasResolver.GlobSemantics"
+    tolerance: 0
+    lean:
+      theorem: "Theorems.ArchAliasResolver.GlobSemantics"
+      status: wip
+      module: "lean/Theorems/ArchAliasResolver.lean"
+
+  determinism:
+    formula: "resolve(r) == resolve(r) for all r"
+    domain: "r: &str"
+    codomain: "AliasVerdict"
+    invariants:
+      - "Resolution is a pure function of input string"
+    preconditions:
+      - "r is valid UTF-8"
+    postconditions:
+      - "Two consecutive calls produce equal verdicts"
+    lean_theorem: "Theorems.ArchAliasResolver.Determinism"
+    tolerance: 0
+    lean:
+      theorem: "Theorems.ArchAliasResolver.Determinism"
+      status: wip
+      module: "lean/Theorems/ArchAliasResolver.lean"
+
+proof_obligations:
+  - type: invariant
+    property: "Resolver is total"
+    formal: "for all repo: &str. resolve(repo) ↦ AliasVerdict"
+    tolerance: 0.0
+    applies_to: alias_total
+    lean:
+      theorem: "Theorems.ArchAliasResolver.Total"
+      module: "ProvableContracts.ArchitectureDemos.ArchAliasResolver"
+  - type: invariant
+    property: "Glob matching is correct"
+    formal: "alias_matches respects '*' suffix-wildcard semantics"
+    tolerance: 0.0
+    applies_to: glob_semantics
+    lean:
+      theorem: "Theorems.ArchAliasResolver.GlobSemantics"
+      module: "ProvableContracts.ArchitectureDemos.ArchAliasResolver"
+  - type: invariant
+    property: "Resolution is deterministic"
+    formal: "resolve(r) == resolve(r)"
+    tolerance: 0.0
+    applies_to: determinism
+    lean:
+      theorem: "Theorems.ArchAliasResolver.Determinism"
+      module: "ProvableContracts.ArchitectureDemos.ArchAliasResolver"
+
+falsification_tests:
+  - id: FALSIFY-ALIAS-001
+    rule: "codellama/* aliases to llama"
+    prediction: "resolve('codellama/CodeLlama-7b-hf') ↦ Ok { resolved_family: 'llama', matched_pattern: 'codellama/*' }"
+    test: "cargo test --example inference_arch_alias_resolver -- codellama_resolves_to_llama"
+    if_fails: "Llama-derivative aliases broken; codellama would no longer dispatch through llama loader"
+  - id: FALSIFY-ALIAS-002
+    rule: "Glob matching rejects mismatched prefix"
+    prediction: "alias_matches('codellama/*', 'meta-llama/Llama-3-8B') == false"
+    test: "cargo test --example inference_arch_alias_resolver -- glob_matches_prefix"
+    if_fails: "Glob semantics drifted; cross-org repos incorrectly resolve through wrong parent"
+  - id: FALSIFY-ALIAS-003
+    rule: "ALIASES covers all 16 blocked-alias backlog entries"
+    prediction: "ALIASES.len() == 16 (matches manifest's alias-eligible blocked count)"
+    test: "cargo test --example inference_arch_alias_resolver -- alias_count_covers_blocked_backlog"
+    if_fails: "Backlog drift; manifest gained an alias entry that the resolver doesn't cover"
+
+kani_harnesses:
+  - id: KANI-ALIAS-001
+    obligation: "Alias resolver is total"
+    bound: 4
+    strategy: bounded_int
+    harness: "kani_harnesses::arch_alias_resolver_total"
+  - id: KANI-ALIAS-002
+    obligation: "Glob matching is deterministic"
+    bound: 4
+    strategy: bounded_int
+    harness: "kani_harnesses::arch_alias_resolver_deterministic"
+
+qa_gate:
+  id: F-ALIAS-001
+  name: "Architecture Alias Resolver Contract"
+  description: "HF-repo-pattern glob → parent family resolution mirroring upstream aprender#1562 alias mechanism"
+  checks:
+    - "resolver_is_total"
+    - "glob_semantics_correct"
+    - "all_16_alias_backlog_covered"
+  pass_criteria: "All three falsification tests pass; ALIASES covers manifest's alias-eligible backlog"

--- a/examples/inference/inference_arch_alias_resolver.rs
+++ b/examples/inference/inference_arch_alias_resolver.rs
@@ -1,0 +1,237 @@
+//! # Architecture Alias Resolver — Demonstrate Upstream Alias Mechanism
+//!
+//! Mirror the upstream `aprender::format::FamilyRegistry::register_alias` /
+//! `resolve_alias` API that aprender PR #1562 adds. This recipe demonstrates
+//! how alias-based family resolution unblocks the 11 derived-model entries
+//! tracked as `status: blocked` in
+//! `docs/specifications/architecture-demos/manifest.yaml` (codellama,
+//! tinyllama, vicuna, yi, smollm, smollm2, codestral, zephyr, dolphin,
+//! hermes, openchat, wizardcoder, distilgpt2, pythia, galactica, codegemma).
+//!
+//! Demonstrates the **ARCH-ALIAS-RESOLVER** recipe per
+//! `docs/specifications/architecture-demos.md` v1.1 + upstream aprender#1562.
+//!
+//! IIUR Contract: contracts/recipe-iiur-v1.yaml
+//! Provable-contract: contracts/inference-arch-alias-resolver-v1.yaml (grade C; lean_status: wip)
+//! Citation: aprender#1562 (FamilyRegistry alias mechanism); manifest.yaml blocked-entries catalog
+//!
+//! Run with: cargo run --example inference_arch_alias_resolver
+//!
+//! Added by PMAT-313 (architecture-demos v1.1: upstream alias resolver demo).
+
+use apr_cookbook::recipe::RecipeContext;
+use apr_cookbook::Result;
+
+/// Registered aliases: HF repo glob → parent family. Mirrors what a caller
+/// would set up upstream via `FamilyRegistry::register_alias`.
+const ALIASES: &[(&str, &str)] = &[
+    // Llama derivatives
+    ("codellama/*", "llama"),
+    ("TinyLlama/*", "llama"),
+    ("lmsys/vicuna-*", "llama"),
+    ("01-ai/Yi-*", "llama"),
+    ("HuggingFaceTB/SmolLM-*", "llama"),
+    ("HuggingFaceTB/SmolLM2-*", "llama"),
+    // Mistral derivatives
+    ("mistralai/Codestral-*", "mistral"),
+    ("HuggingFaceH4/zephyr-*", "mistral"),
+    // Hybrid (could match multiple parents — first match wins)
+    ("cognitivecomputations/dolphin-*", "llama"),
+    ("NousResearch/Hermes-*", "llama"),
+    ("openchat/openchat-*", "llama"),
+    ("WizardLM/WizardCoder-*", "llama"),
+    // Single-loader aliases
+    ("distilbert/distilgpt2", "gpt2"),
+    ("EleutherAI/pythia-*", "gptneox"),
+    ("facebook/galactica-*", "opt"),
+    ("google/codegemma-*", "gemma"),
+];
+
+#[derive(Debug, PartialEq)]
+pub enum AliasVerdict {
+    Ok {
+        hf_repo: String,
+        resolved_family: String,
+        matched_pattern: String,
+    },
+    NoMatch {
+        hf_repo: String,
+    },
+    InvalidInput,
+}
+
+pub fn resolve(hf_repo: &str) -> AliasVerdict {
+    if hf_repo.is_empty() {
+        return AliasVerdict::InvalidInput;
+    }
+    for (pattern, parent) in ALIASES {
+        if alias_matches(pattern, hf_repo) {
+            return AliasVerdict::Ok {
+                hf_repo: hf_repo.to_string(),
+                resolved_family: (*parent).to_string(),
+                matched_pattern: (*pattern).to_string(),
+            };
+        }
+    }
+    AliasVerdict::NoMatch {
+        hf_repo: hf_repo.to_string(),
+    }
+}
+
+/// Glob match: `*` is suffix wildcard. e.g., "codellama/*" matches
+/// "codellama/CodeLlama-7b-hf". Same logic as upstream
+/// `aprender::format::family_registry::alias_matches`.
+fn alias_matches(pattern: &str, hf_repo: &str) -> bool {
+    if let Some(prefix) = pattern.strip_suffix('*') {
+        hf_repo.starts_with(prefix)
+    } else {
+        pattern == hf_repo
+    }
+}
+
+fn main() -> Result<()> {
+    let _ctx = RecipeContext::new("inference_arch_alias_resolver")?;
+    let probes = [
+        "codellama/CodeLlama-7b-hf",
+        "TinyLlama/TinyLlama-1.1B-Chat-v1.0",
+        "EleutherAI/pythia-70m",
+        "google/codegemma-7b",
+        "mistralai/Codestral-22B-v0.1",
+        "openai/gpt-4-turbo",               // unsupported
+        "meta-llama/Llama-3.1-8B-Instruct", // not aliased — caller would use detector
+    ];
+    for repo in probes {
+        match resolve(repo) {
+            AliasVerdict::Ok {
+                resolved_family,
+                matched_pattern,
+                ..
+            } => println!("  {repo:<48} ↦ {resolved_family} (via {matched_pattern})"),
+            AliasVerdict::NoMatch { .. } => {
+                println!("  {repo:<48} ↦ NoMatch (caller falls through to detector)");
+            }
+            AliasVerdict::InvalidInput => println!("  invalid: {repo}"),
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn alias_resolver_runs() {
+        main().expect("recipe execution failed");
+    }
+
+    #[test]
+    fn empty_input_invalid() {
+        assert_eq!(resolve(""), AliasVerdict::InvalidInput);
+    }
+
+    #[test]
+    fn codellama_resolves_to_llama() {
+        if let AliasVerdict::Ok {
+            resolved_family,
+            matched_pattern,
+            ..
+        } = resolve("codellama/CodeLlama-7b-hf")
+        {
+            assert_eq!(resolved_family, "llama");
+            assert_eq!(matched_pattern, "codellama/*");
+        } else {
+            panic!("expected Ok");
+        }
+    }
+
+    #[test]
+    fn tinyllama_resolves_to_llama() {
+        if let AliasVerdict::Ok {
+            resolved_family, ..
+        } = resolve("TinyLlama/TinyLlama-1.1B-Chat-v1.0")
+        {
+            assert_eq!(resolved_family, "llama");
+        }
+    }
+
+    #[test]
+    fn pythia_resolves_to_gptneox() {
+        if let AliasVerdict::Ok {
+            resolved_family, ..
+        } = resolve("EleutherAI/pythia-70m")
+        {
+            assert_eq!(resolved_family, "gptneox");
+        }
+    }
+
+    #[test]
+    fn galactica_resolves_to_opt() {
+        if let AliasVerdict::Ok {
+            resolved_family, ..
+        } = resolve("facebook/galactica-1.3b")
+        {
+            assert_eq!(resolved_family, "opt");
+        }
+    }
+
+    #[test]
+    fn codestral_resolves_to_mistral() {
+        if let AliasVerdict::Ok {
+            resolved_family, ..
+        } = resolve("mistralai/Codestral-22B-v0.1")
+        {
+            assert_eq!(resolved_family, "mistral");
+        }
+    }
+
+    #[test]
+    fn distilgpt2_exact_match() {
+        // distilgpt2 is registered as exact, not glob — different code path.
+        if let AliasVerdict::Ok {
+            resolved_family,
+            matched_pattern,
+            ..
+        } = resolve("distilbert/distilgpt2")
+        {
+            assert_eq!(resolved_family, "gpt2");
+            assert_eq!(matched_pattern, "distilbert/distilgpt2");
+        }
+    }
+
+    #[test]
+    fn unaliased_repo_returns_nomatch() {
+        // Llama itself isn't aliased — caller's detector handles it.
+        assert!(matches!(
+            resolve("meta-llama/Llama-3.1-8B-Instruct"),
+            AliasVerdict::NoMatch { .. }
+        ));
+    }
+
+    #[test]
+    fn unknown_org_returns_nomatch() {
+        assert!(matches!(
+            resolve("openai/gpt-4-turbo"),
+            AliasVerdict::NoMatch { .. }
+        ));
+    }
+
+    #[test]
+    fn alias_count_covers_blocked_backlog() {
+        // Should cover all 16 alias-eligible blocked families from manifest.yaml.
+        assert_eq!(ALIASES.len(), 16);
+    }
+
+    #[test]
+    fn glob_matches_prefix() {
+        assert!(alias_matches("codellama/*", "codellama/CodeLlama-7b-hf"));
+        assert!(!alias_matches("codellama/*", "meta-llama/Llama-3-8B"));
+    }
+
+    #[test]
+    fn deterministic_across_runs() {
+        let a = resolve("codellama/CodeLlama-7b-hf");
+        let b = resolve("codellama/CodeLlama-7b-hf");
+        assert_eq!(a, b);
+    }
+}

--- a/examples/inference/inference_arch_detector.rs
+++ b/examples/inference/inference_arch_detector.rs
@@ -11,10 +11,23 @@
 //! Demonstrates the **ARCH-DETECTOR** recipe per
 //! `docs/specifications/architecture-demos.md` v1.1.
 //!
-//! Mirrors the dispatch logic that upstream `aprender::rosetta::detect_family_from_config`
-//! could adopt: pattern-match the config's distinguishing fields against
-//! the 16 per-family discriminators that the architecture-demos manifest
-//! enumerates.
+//! ## Upstream contribution
+//!
+//! This recipe's dispatch logic was lifted upstream into
+//! `aprender::format::FamilyRegistry::detect_from_config_str` (aprender PR
+//! [#1562](https://github.com/paiml/aprender/pull/1562)). When apr-cookbook
+//! bumps its aprender pin to a release containing #1562, this recipe will
+//! be refactored to call the upstream API directly:
+//!
+//! ```ignore
+//! use aprender::format::FamilyRegistry;
+//! let family = FamilyRegistry::detect_from_config_str(&body); // Option<&'static str>
+//! ```
+//!
+//! Until then, the body of this recipe is the reference implementation
+//! the upstream API mirrors verbatim — same priority order, same
+//! discriminator catalog. The 22 unit tests serve as a falsification
+//! contract on the upstream behavior.
 //!
 //! IIUR Contract: contracts/recipe-iiur-v1.yaml
 //! Provable-contract: contracts/inference-arch-detector-v1.yaml (grade C; lean_status: wip)

--- a/tests/contracts.rs
+++ b/tests/contracts.rs
@@ -30,6 +30,7 @@ const CONTRACT_FILES: &[&str] = &[
     "docs-schema-v1.yaml",
     "flash-attention-v1.yaml",
     // architecture-demos (PMAT-300+): one per family + cross-family detector (PMAT-309).
+    "inference-arch-alias-resolver-v1.yaml",
     "inference-arch-compare-v1.yaml",
     "inference-arch-detector-v1.yaml",
     "inference-arch-quirk-audit-v1.yaml",


### PR DESCRIPTION
Stacked on #414. Bridges apr-cookbook to **aprender PR #1562** (`FamilyRegistry::register_alias` + `detect_from_config_str`).

## Cross-repo upstream bridge

This PR documents and demonstrates the upstream contribution at **[paiml/aprender#1562](https://github.com/paiml/aprender/pull/1562)** which lifts the cookbook's PMAT-309 detector + adds an alias mechanism that unblocks 16 of the 25 `status: blocked` entries in the manifest.

## Two changes

1. `inference_arch_detector.rs` doc-header: documents that the dispatch logic was lifted upstream. Recipe will refactor to `FamilyRegistry::detect_from_config_str` once apr-cookbook bumps aprender pin.

2. `inference_arch_alias_resolver.rs` (new): demonstrates the upstream alias mechanism with all 16 alias-eligible blocked entries:
   - **Llama derivatives** (10): codellama, tinyllama, vicuna, yi, smollm, smollm2, dolphin, hermes, openchat, wizardcoder
   - **Mistral derivatives** (2): codestral, zephyr
   - **Single-loader aliases** (4): distilgpt2→gpt2, pythia→gptneox, galactica→opt, codegemma→gemma
   - 13 unit tests including codellama→llama, glob prefix matching, exact match (distilgpt2), determinism

Contract scores 0.65 Grade C, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)