### PR TITLE
docs: PMAT-314 spec retrofit — v1.1 status + upstream bridge documentation

### DIFF
--- a/docs/specifications/architecture-demos.md
+++ b/docs/specifications/architecture-demos.md
@@ -1,7 +1,7 @@
 # Architecture Demos Specification
 
-**Version**: 1.0.0
-**Status**: ACTIVE (PMAT-300..307 implemented; CI gate enforced)
+**Version**: 1.1.0
+**Status**: ACTIVE (PMAT-300..313 implemented; CI gate enforced; upstream contribution aprender#1562)
 **MSRV**: 1.89 (inherits from apr-cookbook v6.0)
 **Date**: 2026-05-07
 **Repository**: [github.com/paiml/apr-cookbook](https://github.com/paiml/apr-cookbook)
@@ -17,7 +17,9 @@ The unit is the architecture, not the model. HF hosts millions of model repos bu
 
 apr-cookbook today implements **Qwen2 only** (in `aprender-core/src/models/qwen2/`), with one-off recipes (`convert_phi_to_apr.rs`, `inference_qwen3_moe_numerical_parity_smoke.rs`) for two more. A user landing on the cookbook learns nothing about whether Llama, Mistral, Gemma, Phi, DeepSeek, Falcon, BLOOM, MAMBA, or any of the 35+ remaining families are supported. This spec proposes ~43 new recipes (one per family) plus the upstream `aprender::rosetta` loader registry that backs them.
 
-**Net additions:** 43 recipe artifacts split between `examples/inference/` (smoke loads) and `examples/conversion/` (HF-format converters where non-trivial), plus a manifest-driven coverage gate that forces the cookbook to track upstream architecture support.
+**Net additions (v1, PMAT-300..308):** 18 family-smoke recipes + 17 provable-contracts + 18 fixtures, plus a manifest-driven coverage gate that forces the cookbook to track upstream architecture support.
+
+**v1.1 expansion (PMAT-309..313):** 5 cross-family meta-recipes — detector (PMAT-309), summary (PMAT-310), compare (PMAT-311), quirk-audit (PMAT-312), alias-resolver (PMAT-313) — plus upstream contribution to `aprender::format::FamilyRegistry` ([aprender#1562](https://github.com/paiml/aprender/pull/1562)) lifting the discriminator-dispatch logic and adding the alias mechanism. Cookbook recipes act as the falsification suite for the upstream API; the cookbook→upstream bridge becomes a first-class pattern documented in [scope.md](architecture-demos/scope.md#upstream-contribution-discipline).
 
 ---
 

--- a/docs/specifications/architecture-demos/manifest.yaml
+++ b/docs/specifications/architecture-demos/manifest.yaml
@@ -289,7 +289,7 @@ families:
     hf_architectures: [GemmaForCausalLM] # shares Gemma loader; alias when gemma loader lands
     hf_pattern: "google/codegemma-*"
     status: blocked
-    upstream_ticket: "aprender#TODO-codegemma-alias"
+    upstream_ticket: "aprender#1562 (alias mechanism — unblocks once released)"
     notes: "Aliases the gemma family; awaits hf_pattern alias support in aprender::rosetta."
   - name: codellama
     display_name: "CodeLlama"
@@ -297,7 +297,7 @@ families:
     hf_architectures: [LlamaForCausalLM]
     hf_pattern: "codellama/CodeLlama-*"
     status: blocked
-    upstream_ticket: "aprender#TODO-codellama-alias"
+    upstream_ticket: "aprender#1562 (alias mechanism — unblocks once released)"
     notes: "Aliases the llama family; same loader, different vocab."
   - name: codestral
     display_name: "Codestral"
@@ -305,13 +305,13 @@ families:
     hf_architectures: [MistralForCausalLM]
     hf_pattern: "mistralai/Codestral-*"
     status: blocked
-    upstream_ticket: "aprender#TODO-codestral-alias"
+    upstream_ticket: "aprender#1562 (alias mechanism — unblocks once released)"
   - name: dolphin
     display_name: "Dolphin"
     vendor: cognitivecomputations
     hf_architectures: [LlamaForCausalLM, MistralForCausalLM]
     status: blocked
-    upstream_ticket: "aprender#TODO-dolphin-alias"
+    upstream_ticket: "aprender#1562 (alias mechanism — unblocks once released)"
   - name: falcon
     display_name: "Falcon (classic)"
     vendor: TII
@@ -325,7 +325,7 @@ families:
     vendor: "Meta AI"
     hf_architectures: [OPTForCausalLM] # actually uses OPT loader
     status: blocked
-    upstream_ticket: "aprender#TODO-galactica-alias"
+    upstream_ticket: "aprender#1562 (alias mechanism — unblocks once released)"
   - name: granite
     display_name: "Granite"
     vendor: IBM
@@ -338,7 +338,7 @@ families:
     vendor: NousResearch
     hf_architectures: [LlamaForCausalLM, MistralForCausalLM]
     status: blocked
-    upstream_ticket: "aprender#TODO-hermes-alias"
+    upstream_ticket: "aprender#1562 (alias mechanism — unblocks once released)"
   - name: internlm2_5
     display_name: "InternLM2.5"
     vendor: InternLM
@@ -364,14 +364,14 @@ families:
     vendor: openchat
     hf_architectures: [LlamaForCausalLM, MistralForCausalLM]
     status: blocked
-    upstream_ticket: "aprender#TODO-openchat-alias"
+    upstream_ticket: "aprender#1562 (alias mechanism — unblocks once released)"
   - name: pythia
     display_name: "Pythia"
     vendor: EleutherAI
     hf_architectures: [GPTNeoXForCausalLM]
     hf_pattern: "EleutherAI/pythia-*"
     status: blocked
-    upstream_ticket: "aprender#TODO-pythia-alias"
+    upstream_ticket: "aprender#1562 (alias mechanism — unblocks once released)"
     notes: "Aliases gptneox loader."
   - name: smollm
     display_name: "SmolLM"
@@ -379,14 +379,14 @@ families:
     hf_architectures: [LlamaForCausalLM]
     hf_pattern: "HuggingFaceTB/SmolLM-*"
     status: blocked
-    upstream_ticket: "aprender#TODO-smollm-alias"
+    upstream_ticket: "aprender#1562 (alias mechanism — unblocks once released)"
   - name: smollm2
     display_name: "SmolLM2"
     vendor: HuggingFace
     hf_architectures: [LlamaForCausalLM]
     hf_pattern: "HuggingFaceTB/SmolLM2-*"
     status: blocked
-    upstream_ticket: "aprender#TODO-smollm2-alias"
+    upstream_ticket: "aprender#1562 (alias mechanism — unblocks once released)"
   - name: stablelm
     display_name: "StableLM"
     vendor: "Stability AI"
@@ -406,34 +406,34 @@ families:
     hf_architectures: [LlamaForCausalLM]
     hf_pattern: "TinyLlama/*"
     status: blocked
-    upstream_ticket: "aprender#TODO-tinyllama-alias"
+    upstream_ticket: "aprender#1562 (alias mechanism — unblocks once released)"
   - name: vicuna
     display_name: "Vicuna"
     vendor: lmsys
     hf_architectures: [LlamaForCausalLM]
     hf_pattern: "lmsys/vicuna-*"
     status: blocked
-    upstream_ticket: "aprender#TODO-vicuna-alias"
+    upstream_ticket: "aprender#1562 (alias mechanism — unblocks once released)"
   - name: wizardcoder
     display_name: "WizardCoder"
     vendor: WizardLM
     hf_architectures: [LlamaForCausalLM, MistralForCausalLM]
     status: blocked
-    upstream_ticket: "aprender#TODO-wizardcoder-alias"
+    upstream_ticket: "aprender#1562 (alias mechanism — unblocks once released)"
   - name: yi
     display_name: "Yi"
     vendor: 01-ai
     hf_architectures: [LlamaForCausalLM]
     hf_pattern: "01-ai/Yi-*"
     status: blocked
-    upstream_ticket: "aprender#TODO-yi-alias"
+    upstream_ticket: "aprender#1562 (alias mechanism — unblocks once released)"
   - name: zephyr
     display_name: "Zephyr"
     vendor: HuggingFaceH4
     hf_architectures: [MistralForCausalLM]
     hf_pattern: "HuggingFaceH4/zephyr-*"
     status: blocked
-    upstream_ticket: "aprender#TODO-zephyr-alias"
+    upstream_ticket: "aprender#1562 (alias mechanism — unblocks once released)"
   - name: tiny_starcoder_py
     display_name: "Tiny StarCoder Python"
     vendor: bigcode
@@ -447,5 +447,5 @@ families:
     hf_architectures: [GPT2LMHeadModel]
     hf_pattern: "distilbert/distilgpt2"
     status: blocked
-    upstream_ticket: "aprender#TODO-distilgpt2-alias"
+    upstream_ticket: "aprender#1562 (alias mechanism — unblocks once released)"
     notes: "Aliases gpt2 loader; awaits alias support."

--- a/docs/specifications/architecture-demos/scope.md
+++ b/docs/specifications/architecture-demos/scope.md
@@ -54,6 +54,23 @@ The architecture-demos initiative does **not** cover:
 - ❌ GPU-required CI gates — CPU smoke is the floor, GPU is `#[cfg_attr(not(feature = "cuda"), ignore)]`
 - ❌ Implementing upstream loaders — `status: blocked` entries are tracked, not resolved here
 
+## Upstream Contribution Discipline
+
+Added in v1.1 (PMAT-313). When a cookbook meta-recipe surfaces a primitive that genuinely belongs upstream — not a one-off demo, but a reusable API surface that other consumers would want — it gets lifted into `aprender-core` and the cookbook recipe becomes the falsification suite for the upstream API.
+
+Concrete instance: PMAT-309's `inference_arch_detector.rs` reverse-engineered a discriminator-dispatch table from the 18 family-smoke recipes. PMAT-313 lifted that dispatch table into `aprender::format::FamilyRegistry::detect_from_config_str` ([aprender#1562](https://github.com/paiml/aprender/pull/1562)) plus added a `register_alias` mechanism that unblocks 16 of the 25 `status: blocked` manifest entries.
+
+Pattern when this applies:
+1. A cookbook recipe demonstrates a primitive that maps cleanly to upstream's domain (architecture inspection, loader dispatch, …)
+2. The recipe's tests serve as a falsification contract on the upstream behavior
+3. Upstream PR adds the public API; cookbook recipe doc-header documents the upstream destination
+4. After the upstream PR ships in a release, cookbook bumps its aprender pin and the recipe refactors to call the upstream API directly (the tests become integration tests for upstream)
+
+Pattern when this does NOT apply:
+- Recipe is genuinely cookbook-specific (depends on `RecipeContext`, IIUR plumbing, etc.)
+- Recipe is a thin wrapper over an existing upstream API (no new primitive)
+- Recipe is exploratory — not yet stabilized enough to bake into upstream
+
 ## Versioning
 
-apr-cookbook spec bumps from v6.1.0 → **v6.2.0** after architecture-demos lands (minor: additive, no breaking re-categorization). The architecture-demos spec itself stays at v1.0.0 — the manifest evolves continuously without spec re-version.
+apr-cookbook spec bumps from v6.1.0 → **v6.2.0** after architecture-demos v1 lands (PMAT-308). v1.1 (PMAT-309..313) is additive within v6.2.x — the architecture-demos spec bumps to **1.1.0** to reflect the cross-family meta-recipe expansion + upstream-contribution discipline.

--- a/docs/specifications/architecture-demos/tickets.md
+++ b/docs/specifications/architecture-demos/tickets.md
@@ -1,6 +1,8 @@
 # PMAT Ticket Breakdown
 
-Architecture-demos work splits into **8 PMAT tickets** plus 1 prerequisite. Family batches group ~3 families per ticket so each is independently shippable. Each family ticket authors **both** the smoke recipe AND a per-family provable-contract YAML, then gates manifest-flip on `pv lint` + `pv score` grade C minimum. Ticket numbers are placeholders; actual numbers assigned by `pmat work add` at execution time.
+Architecture-demos work has shipped two waves: **v1 (PMAT-300..308, 9 tickets)** built one smoke recipe per family with a provable-contract; **v1.1 (PMAT-309..314, 6 tickets)** added cross-family meta-recipes plus the upstream-bridge to `aprender::format::FamilyRegistry` ([aprender#1562](https://github.com/paiml/aprender/pull/1562)).
+
+Each ticket authors recipe(s) + provable-contract YAML + (where applicable) fixture + tests, gating manifest-flip on `pv lint` + `pv score` grade C minimum. PMAT numbers are real ticket IDs assigned at landing time.
 
 | Ticket | Scope | Priority | Estimate | Depends on |
 |--------|-------|----------|----------|------------|
@@ -57,7 +59,7 @@ Total: ~20.5 dev-days (vs 14.5 IIUR-only — contract authoring adds ~0.5 day pe
 3. Demonstrate all three formats: safetensors, apr, gguf.
 4. Author `contracts/inference-llama-smoke-v1.yaml` — fill in concrete pre/postconditions for `loader_dispatch`, `tensor_validation`, `forward_determinism`. Reference Lean theorems (`Theorems.Llama.LoaderDispatch`, etc.) at `lean.status: wip` until proofs land.
 5. Flip manifest entry `llama: status: in-progress` → `certified` only after `pv lint` and `pv score --summary` (grade C minimum) both pass.
-6. Open upstream aprender ticket `aprender#TODO-llama-aliases` requesting alias mechanism for codellama/dolphin/hermes/openchat/smollm/smollm2/tinyllama/vicuna/wizardcoder/yi (10 aliases unblock as a batch when this lands).
+6. Open upstream aprender ticket `aprender#1562` (alias mechanism resolved) for codellama/dolphin/hermes/openchat/smollm/smollm2/tinyllama/vicuna/wizardcoder/yi (10 aliases unblock as a batch when this lands).
 7. Update [coverage-matrix.md](coverage-matrix.md) via generator.
 
 ### Definition of Done
@@ -153,7 +155,7 @@ Gemma demonstrates GGUF; GPT-2 demonstrates f32 (smallest models still ship full
 
 - All 3 recipes pass tests.
 - Manifest entries flipped to `certified`.
-- Open `aprender#TODO-codegemma-alias`, `aprender#TODO-distilgpt2-alias`, `aprender#TODO-pythia-alias` (3 aliases unblock).
+- Open `aprender#1562` (alias mechanism unblocks codegemma + distilgpt2 + pythia) (3 aliases unblock).
 
 ---
 
@@ -199,7 +201,7 @@ BERT is the only encoder-only family in v1; the verdict shape may need a fourth 
 
 - All 4 recipes pass tests.
 - Manifest entries flipped to `certified`.
-- Open `aprender#TODO-galactica-alias` (OPT-shared).
+- Open `aprender#1562` (alias mechanism unblocks galactica) (OPT-shared).
 - Recipe-template note added for encoder-only verdict shape.
 
 ---
@@ -229,8 +231,25 @@ BERT is the only encoder-only family in v1; the verdict shape may need a fourth 
 
 ---
 
-## Backlog (post-architecture-demos v1)
+## v1.1 Expansion (PMAT-309..314) — Cross-Family Meta-Recipes + Upstream Bridge
 
-- Resolution of `status: blocked` entries — driven by upstream aprender alias mechanism + new loaders. Each blocked-family unblock is a separate small ticket (PMAT-310..3??), tracked individually.
-- Vision/audio/multimodal expansion (LLaVA, SDXL, ViT) — separate spec, not in this scope.
+After v1 closeout (PMAT-308), the spec was extended with cross-family meta-recipes and an upstream-contribution bridge. The unit of v1.1 is no longer "one recipe per family" but "primitives that operate across the family suite".
+
+| Ticket | Scope | PR |
+|--------|-------|----|
+| PMAT-309 | Cross-family detector — discriminator-dispatch from raw config.json to family name | #413 (combined with PMAT-310) |
+| PMAT-310 | Family summary — discriminator catalog across all 16 families | #413 |
+| PMAT-311 | Cross-family compare — diff two configs, classify FamilyRelation | #414 (combined with PMAT-312) |
+| PMAT-312 | Quirk audit — flag configs matching >1 family discriminator | #414 |
+| PMAT-313 | Upstream bridge — alias-resolver demo + cookbook→aprender contribution ([aprender#1562](https://github.com/paiml/aprender/pull/1562)) | #415 + aprender#1562 |
+| PMAT-314 | Spec retrofit — bump status, document v1.1, refresh upstream-ticket links in manifest | this PR |
+
+Each v1.1 ticket follows the same IIUR + provable-contract discipline as v1. The 5 meta-recipes ship 22+11+12+10+13 = 68 unit tests across the family suite.
+
+## Backlog (post-architecture-demos v1.1)
+
+- **Refactor cookbook detector to consume upstream API** — when aprender ships a release containing #1562, bump the cookbook's aprender pin and replace `inference_arch_detector.rs` body with a thin call to `FamilyRegistry::detect_from_config_str`. The 22 detector tests become integration tests for the upstream API.
+- **Resolution of `status: blocked` entries** — 16 of 25 are alias-eligible (codellama, tinyllama, vicuna, yi, smollm, smollm2, dolphin, hermes, openchat, wizardcoder, codestral, zephyr, distilgpt2, pythia, galactica, codegemma) and unblock via aprender#1562's `register_alias` once it ships. The remaining 9 (bloom, falcon-classic, granite, internlm2_5, nemotron, olmo, stablelm, starcoder2, tiny_starcoder_py) need new upstream loaders, deferred per scope non-goal.
+- **Lift contracts C→A** — contracts currently score 0.65 Grade C (D1/D2 perfect, D3 Kani 0.6, D4 Lean 0.0, D5 Binding 0.0). Lifting to Grade A requires real Kani harness implementations + Lean theorem files. Tracked as a separate substantial-effort initiative.
+- **Vision/audio/multimodal expansion** (LLaVA, SDXL, ViT) — separate v2 spec, not in current scope.
 - ONNX format coverage — none of the 18 in-progress loaders ship ONNX; awaits upstream support.


### PR DESCRIPTION
Stacked on #415. Doc-only retrofit aligning the spec with PMAT-309..313 implementation reality.

## Four files updated

| File | Change |
|------|--------|
| `architecture-demos.md` | Status PROPOSED→PMAT-300..313 ACTIVE (+ aprender#1562); version 1.0.0→1.1.0; exec summary describes v1 and v1.1 |
| `scope.md` | New 'Upstream Contribution Discipline' section documenting the cookbook→aprender pattern; versioning section reflects 1.1.0 |
| `tickets.md` | Header rewritten (15 tickets across v1+v1.1, not 8); new v1.1 section with PMAT-309..314 entries; backlog rewritten with concrete next steps; 3 placeholder TODO strings updated to aprender#1562 |
| `manifest.yaml` | 16 alias-eligible blocked entries updated upstream_ticket from `aprender#TODO-*-alias` to `aprender#1562`; 9 new-loader entries keep their TODO placeholders (need different upstream work) |

## Why retrofit was needed

PMAT-309..313 landed (PRs #413, #414, #415) but the spec was never updated. Status line still said 'PMAT-300..307 implemented'. tickets.md backlog said PMAT-310 was unallocated when in fact it was the summary recipe ticket. The cookbook→upstream bridge pattern (PMAT-313 + aprender#1562) had no documented home in scope.md.

Doc-only — no code changes. `make architecture-demos-coverage` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)