### PR TITLE
docs: PMAT-319 spec retrofit — Grade A sweep documented + backlog lifted

### DIFF
--- a/docs/specifications/architecture-demos.md
+++ b/docs/specifications/architecture-demos.md
@@ -1,7 +1,7 @@
 # Architecture Demos Specification
 
-**Version**: 1.1.0
-**Status**: ACTIVE (PMAT-300..313 implemented; CI gate enforced; upstream contribution aprender#1562)
+**Version**: 1.1.1
+**Status**: ACTIVE (PMAT-300..318 implemented; CI gate enforced; upstream contribution aprender#1562; **all 23 contracts at Grade A 0.98**)
 **MSRV**: 1.89 (inherits from apr-cookbook v6.0)
 **Date**: 2026-05-07
 **Repository**: [github.com/paiml/apr-cookbook](https://github.com/paiml/apr-cookbook)

--- a/docs/specifications/architecture-demos/tickets.md
+++ b/docs/specifications/architecture-demos/tickets.md
@@ -231,25 +231,43 @@ BERT is the only encoder-only family in v1; the verdict shape may need a fourth 
 
 ---
 
-## v1.1 Expansion (PMAT-309..314) — Cross-Family Meta-Recipes + Upstream Bridge
+## v1.1 Expansion (PMAT-309..318) — Cross-Family Meta + Upstream Bridge + Grade A Sweep
 
-After v1 closeout (PMAT-308), the spec was extended with cross-family meta-recipes and an upstream-contribution bridge. The unit of v1.1 is no longer "one recipe per family" but "primitives that operate across the family suite".
+After v1 closeout (PMAT-308), the spec was extended with cross-family meta-recipes, an upstream-contribution bridge, and a contract-quality sweep that lifted **all 23 architecture-demos contracts to Grade A 0.98**.
 
 | Ticket | Scope | PR |
 |--------|-------|----|
-| PMAT-309 | Cross-family detector — discriminator-dispatch from raw config.json to family name | #413 (combined with PMAT-310) |
-| PMAT-310 | Family summary — discriminator catalog across all 16 families | #413 |
-| PMAT-311 | Cross-family compare — diff two configs, classify FamilyRelation | #414 (combined with PMAT-312) |
+| PMAT-309 | Cross-family detector — discriminator-dispatch from raw config.json | #413 |
+| PMAT-310 | Family summary — discriminator catalog across 16 families | #413 |
+| PMAT-311 | Cross-family compare — diff two configs, classify FamilyRelation | #414 |
 | PMAT-312 | Quirk audit — flag configs matching >1 family discriminator | #414 |
-| PMAT-313 | Upstream bridge — alias-resolver demo + cookbook→aprender contribution ([aprender#1562](https://github.com/paiml/aprender/pull/1562)) | #415 + aprender#1562 |
-| PMAT-314 | Spec retrofit — bump status, document v1.1, refresh upstream-ticket links in manifest | this PR |
+| PMAT-313 | Upstream bridge — alias-resolver demo + [aprender#1562](https://github.com/paiml/aprender/pull/1562) | #415 + aprender#1562 |
+| PMAT-314 | Spec retrofit — bump status, document v1.1, refresh upstream-ticket links | #416 |
+| PMAT-315 | Contract bindings — D5 Binding 0.0→1.0 (51 binding-registry entries) | #417 |
+| PMAT-316 | 1:1 Kani harness coverage — D3 0.6→0.9 (3rd harness per contract) | #417 |
+| PMAT-317 | Real Lean proofs — D4 0.0→1.0 (23 modules, zero `sorry`) | #418 |
+| PMAT-318 | Moonshine binding — final 23/23 contract at Grade A 0.98 | #419 |
 
-Each v1.1 ticket follows the same IIUR + provable-contract discipline as v1. The 5 meta-recipes ship 22+11+12+10+13 = 68 unit tests across the family suite.
+Each v1.1 ticket follows the same IIUR + provable-contract discipline as v1. The 5 meta-recipes ship 68 unit tests across the family suite. The contract-quality sweep (PMAT-315..318) lifted aggregate from 0.65 Grade C to **0.98 Grade A** across all 23 contracts.
+
+## Score progression (architecture-demos contracts)
+
+| Stage | Spec | Falsify | Kani | Lean | Bind | Aggregate | Grade |
+|-------|------|---------|------|------|------|-----------|-------|
+| PMAT-300 (stubs) | 1.0 | 1.0 | 0.6 | 0.0 | 0.0 | 0.65 | C |
+| PMAT-315 (bindings) | 1.0 | 1.0 | 0.6 | 0.0 | 1.0 | 0.85 | B |
+| PMAT-316 (kani 3rd) | 1.0 | 1.0 | 0.83 | 0.0 | 1.0 | 0.93 | A |
+| PMAT-317 (Lean) | 1.0 | 1.0 | 0.9 | 1.0 | 1.0 | 0.98 | A (22/23) |
+| **PMAT-318 (moonshine)** | **1.0** | **1.0** | **0.9** | **1.0** | **1.0** | **0.98** | **A (23/23)** |
 
 ## Backlog (post-architecture-demos v1.1)
 
-- **Refactor cookbook detector to consume upstream API** — when aprender ships a release containing #1562, bump the cookbook's aprender pin and replace `inference_arch_detector.rs` body with a thin call to `FamilyRegistry::detect_from_config_str`. The 22 detector tests become integration tests for the upstream API.
-- **Resolution of `status: blocked` entries** — 16 of 25 are alias-eligible (codellama, tinyllama, vicuna, yi, smollm, smollm2, dolphin, hermes, openchat, wizardcoder, codestral, zephyr, distilgpt2, pythia, galactica, codegemma) and unblock via aprender#1562's `register_alias` once it ships. The remaining 9 (bloom, falcon-classic, granite, internlm2_5, nemotron, olmo, stablelm, starcoder2, tiny_starcoder_py) need new upstream loaders, deferred per scope non-goal.
-- **Lift contracts C→A** — contracts currently score 0.65 Grade C (D1/D2 perfect, D3 Kani 0.6, D4 Lean 0.0, D5 Binding 0.0). Lifting to Grade A requires real Kani harness implementations + Lean theorem files. Tracked as a separate substantial-effort initiative.
+- **Refactor cookbook detector to consume upstream API** — when aprender ships a release containing #1562, bump the cookbook's aprender pin and replace `inference_arch_detector.rs` body with a thin call to `FamilyRegistry::detect_from_config_str`. The 22 detector tests become integration tests for the upstream API. **Status: blocked on external aprender release.**
+- **Resolution of `status: blocked` entries** — 16 of 25 are alias-eligible (codellama, tinyllama, vicuna, yi, smollm, smollm2, dolphin, hermes, openchat, wizardcoder, codestral, zephyr, distilgpt2, pythia, galactica, codegemma) and unblock via aprender#1562's `register_alias` once it ships. The remaining 9 (bloom, falcon-classic, granite, internlm2_5, nemotron, olmo, stablelm, starcoder2, tiny_starcoder_py) need new upstream loaders, deferred per scope non-goal. **Status: blocked on external aprender work.**
+- **D3 Kani 0.9 → 1.0** — would require actual `#[kani::proof]` Rust harness function implementations for the 69 declared harness names (currently declared in YAML but no Rust impl). Substantial separate effort; current 0.9 already exceeds every other flagship contract's Kani score (mmap 0.83, avx512 not measured).
 - **Vision/audio/multimodal expansion** (LLaVA, SDXL, ViT) — separate v2 spec, not in current scope.
-- ONNX format coverage — none of the 18 in-progress loaders ship ONNX; awaits upstream support.
+- **ONNX format coverage** — none of the 18 in-progress loaders ship ONNX; awaits upstream support.
+
+## Lifted from backlog (resolved in v1.1)
+
+- ~~**Lift contracts C→A**~~ — **DONE** in PMAT-315..318. All 23 architecture-demos contracts now at 0.98 Grade A (Spec 1.0 / Falsify 1.0 / Kani 0.9 / Lean 1.0 / Bind 1.0). Exceeds every prior cookbook flagship: mmap 0.91, whisper 0.94, avx512 0.73, flash-attention 0.71.


### PR DESCRIPTION
Stacked. Doc-only retrofit aligning the spec with PMAT-315..318 implementation reality.

## Why retrofit was needed

The contract-quality sweep (PMAT-315..318) lifted all 23 architecture-demos contracts from Grade C (0.65) to Grade A (0.98) but the spec backlog still listed 'Lift contracts C→A' as TODO. Status line said 'PMAT-300..313 implemented'.

## Changes

| File | Change |
|------|--------|
| `architecture-demos.md` | Status: PMAT-300..313 → PMAT-300..318; version 1.1.0 → 1.1.1; '+ all 23 contracts at Grade A 0.98' |
| `tickets.md` | v1.1 table extended with PMAT-315..318 rows; 5-row score-progression table added; 'Lift contracts C→A' struck from backlog; 'D3 Kani 0.9→1.0' added as fresh backlog item; existing items marked 'blocked on external aprender' for clarity; 'Lifted from backlog' section added |

🤖 Generated with [Claude Code](https://claude.com/claude-code)