### PR TITLE
chore: PMAT-327 verify kani-gate fires on PR (kani-ci 1.0.0 → 1.0.1)

### DIFF
--- a/docs/specifications/kani-ci.md
+++ b/docs/specifications/kani-ci.md
@@ -1,7 +1,7 @@
 # Kani CI Specification
 
-**Version**: 1.0.0
-**Status**: ACTIVE (PMAT-324 implemented; runs on every PR)
+**Version**: 1.0.1
+**Status**: ACTIVE (PMAT-324 merged on main 2026-05-09 via PR #421; kani-gate + free-disk-space landed; runs on every PR)
 **MSRV**: 1.89 (inherits from apr-cookbook v6.0)
 **Date**: 2026-05-09
 **Repository**: [github.com/paiml/apr-cookbook](https://github.com/paiml/apr-cookbook)


### PR DESCRIPTION
## Summary

Tiny no-op PR to verify the new `kani-gate` CI job + `free-disk-space` step actually fire on a regular PR against `main`. PR #421 (architecture-demos v1.2 + PMAT-324 kani-gate) was admin-merged because `pull_request_target` reads workflows from the base branch — the workflow fixes couldn't validate themselves on their own PR.

## Doc-only diff

- `docs/specifications/kani-ci.md`: version 1.0.0 → 1.0.1; status line notes the 2026-05-09 merge via PR #421.

## Test plan

This PR's CI run is the test:

- [ ] `kani-gate` appears as a check (was missing on PR #421 — workflow not on main yet)
- [ ] `kani-gate` passes (108 harnesses verify in ~14s after Kani install)
- [ ] `Quality Gate (stable)` passes (free-disk-space mitigates the disk-full flake from PR #421)
- [ ] `CI Status` summary lists `gate` + `lean-gate` + `kani-gate` and goes green
- [ ] First-run cold install of Kani 0.67.0 takes 3–5 min; cached for subsequent PRs

If kani-gate fires green: v1.0.0 integration confirmed, ready to move on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)