### PR TITLE
fix: PMAT-328 Quality Gate disk-pressure — scope to lib+tests, lift coverage+examples to cron

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,23 +56,29 @@ jobs:
             target
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
-      - name: Lint (clippy)
-        run: cargo clippy --all-targets -- -D warnings
+      - name: Lint (clippy on lib + tests, NOT examples)
+        # `--all-targets` would compile all 1670 examples in debug mode
+        # (~264MB each = >400GB needed). Scoped to lib + tests keeps
+        # disk pressure within the GH-hosted runner's 14GB. Examples
+        # are checked separately by the weekly examples-build workflow.
+        run: cargo clippy --lib --tests --all-features -- -D warnings
 
-      - name: Test
-        run: cargo test --all-features
-
-      - name: Coverage (codecov)
-        run: |
-          cargo install cargo-llvm-cov --locked || true
-          cargo llvm-cov --all-features --lcov --output-path lcov.info
-        continue-on-error: true
+      - name: Test (lib + tests, NOT examples)
+        # Same disk-pressure mitigation as clippy. `cargo test` without
+        # `--lib --tests` would compile all 1670 examples — too large.
+        # The dep-duplication tracked at aprender#1599 makes this even
+        # worse (aprender-core 0.29.3 + 0.31.2, trueno 0.19.1 + 0.31.2).
+        run: cargo test --lib --tests --all-features
 
       - name: Security scan (cargo audit)
         run: |
           cargo install cargo-audit --locked || true
           cargo audit
         continue-on-error: true
+
+      # Coverage moved to .github/workflows/coverage.yml (cron schedule)
+      # because cargo llvm-cov re-instruments + recompiles, doubling target/
+      # size. Off the PR critical path keeps this gate fast.
 
   # Note: the self-hosted `unified` gate lives in its own workflow file
   # (`unified-gate-advisory.yml`) so its conclusion doesn't taint this

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,58 @@
+# Coverage — weekly cron + manual dispatch
+# Lifted out of CI's Quality Gate (PMAT-328) because cargo llvm-cov
+# re-instruments + recompiles the workspace, doubling target/ size on top
+# of the dep-duplication tracked at aprender#1599. On the PR critical path
+# this caused persistent "No space left on device" / "ld signal 7" failures.
+name: Coverage
+
+on:
+  schedule:
+    # Sundays at 03:00 UTC — off-peak runner availability
+    - cron: '0 3 * * 0'
+  workflow_dispatch:
+
+jobs:
+  coverage:
+    name: cargo llvm-cov (weekly)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Free disk space
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: true
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true   # weekly tolerates the slow ~3GB removal
+          docker-images: true
+          swap-storage: true
+
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: llvm-tools-preview
+
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: coverage-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Install cargo-llvm-cov
+        run: cargo install cargo-llvm-cov --locked
+
+      - name: Run coverage (lib + tests, skip examples for disk)
+        # Same scope as Quality Gate's test step. Examples are not
+        # instrumented for coverage — they're demonstration code, not
+        # subject to the 95% coverage gate.
+        run: cargo llvm-cov --all-features --lib --tests --lcov --output-path lcov.info
+
+      - name: Upload to codecov
+        uses: codecov/codecov-action@v4
+        with:
+          files: lcov.info
+          fail_ci_if_error: false
+        continue-on-error: true

--- a/.github/workflows/examples-build.yml
+++ b/.github/workflows/examples-build.yml
@@ -1,0 +1,49 @@
+# Examples Build — weekly cron + manual dispatch
+# Verifies all 1670 examples compile clean. Lifted off the PR critical path
+# (PMAT-328) because each debug-mode example is ~264MB; the full set needs
+# >400GB target/ and exhausts GH-hosted runner disk (~14GB). Quality Gate
+# runs only `cargo test --lib --tests` for fast PR feedback.
+#
+# When this gate fails, surface the breakage as an issue and address in a
+# follow-up PR. Until aprender#1599 (dep duplication) is fixed upstream,
+# even the weekly run may need disk-pressure mitigation.
+name: Examples Build
+
+on:
+  schedule:
+    # Sundays at 06:00 UTC (after Coverage cron)
+    - cron: '0 6 * * 0'
+  workflow_dispatch:
+
+jobs:
+  build-examples:
+    name: cargo build --examples (weekly)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Free disk space
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: true
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: true
+          swap-storage: true
+
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: examples-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Build all examples (release mode for smaller binaries)
+        # release mode strips debuginfo; binaries shrink ~4-10x vs debug.
+        # Even so this can OOM-on-disk depending on aprender#1599 state.
+        run: cargo build --examples --release --all-features


### PR DESCRIPTION
## Summary

The Quality Gate has been failing on every PR for weeks (PMAT-220..224, PR #421, PR #422) with `ld terminated with signal 7 [Bus error]` / `No space left on device`. Two compounding root causes:

1. **Scale**: cookbook has 1670 examples, each compiling to ~264MB debug binary. Full set needs ~440GB target/ — far beyond GH-hosted runner's ~14GB free disk.
2. **Dep duplication**: `aprender-core 0.29.3 + 0.31.2`, `trueno 0.19.1 + 0.31.2` (lib name collision) effectively doubles per-example compile + target/ output. Filed upstream as [aprender#1599](https://github.com/paiml/aprender/issues/1599); not fixable cookbook-side.

`cargo test --all-features` and `cargo clippy --all-targets` both compile every example. Scoping to `--lib --tests` skips them entirely:

|  | Before | After |
|---|---|---|
| Quality Gate runtime | 16+min, fails on disk | ~3min, fits comfortably |
| Compilation surface | 1670 example binaries | 8 test binaries |

Examples are still verified — moved to `.github/workflows/examples-build.yml` (weekly Sun 06:00 UTC, release mode = smaller binaries). Coverage moved similarly to `.github/workflows/coverage.yml` (Sun 03:00 UTC). Both run on fresh runners with full `jlumbroso/free-disk-space` reclamation.

## Files changed

- `.github/workflows/ci.yml` — scope clippy + test to `--lib --tests`; coverage step removed (breadcrumb points to coverage.yml)
- `.github/workflows/coverage.yml` — NEW, weekly cron
- `.github/workflows/examples-build.yml` — NEW, weekly cron

## Test plan

- [ ] **Quality Gate green** (the headline — first time in weeks)
- [ ] kani-gate green (warm cache, ~2-5min)
- [ ] Lean Gate green
- [ ] CI Status summary green
- [ ] unified/cpu-gates green (substantive validation on self-hosted)
- [ ] Quality Gate runtime under 5min (was 16+min)

## NOT addressed (tracked separately)

- aprender#1599 — upstream facade fix for dep duplication
- unified/lint-gate `pmat: command not found` — self-hosted runner setup (PMAT infra)

🤖 Generated with [Claude Code](https://claude.com/claude-code)