### PR TITLE
chore: disable Unified Gate (advisory) auto-trigger (Refs PMAT-360)

### DIFF
--- a/.github/workflows/unified-gate-advisory.yml
+++ b/.github/workflows/unified-gate-advisory.yml
@@ -19,14 +19,19 @@
 #
 # When the `paiml/infra` `_provision` target is fixed, this workflow goes
 # green automatically — no change needed here.
+#
+# 2026-05-11: Auto-triggers (push / pull_request_target) removed because
+# the `unified-gate.yml` reusable workflow has been failing on every push
+# for weeks: the self-hosted runners (`intel-clean-room-*`) lack `sccache`
+# and `pmat`, so both `cpu-gates` (`cargo install --locked forjar` with
+# `RUSTC_WRAPPER=sccache`) and `lint-gate` (L4 `pmat quality-gate`) exit
+# with errors 2 and 127 respectively. Workflow is preserved for manual
+# dispatch — re-enable the `push` / `pull_request_target` triggers in
+# this file once the org infra is provisioned (see `paiml/.github`).
 
 name: Unified Gate (advisory)
 
 on:
-  pull_request_target:
-    branches: [main, master]
-  push:
-    branches: [main, master]
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## Summary

Stops the `Unified Gate (advisory)` workflow from auto-running on every push.

## Why

It has been red on every push to `main` for ≥ 5 commits because its self-hosted runners (`intel-clean-room-*`) lack two binaries:

- **`sccache`** — `RUSTC_WRAPPER=sccache` is set workflow-wide, so `cargo install --locked forjar` fails immediately in `cpu-gates` with "could not execute process `sccache`" (errno 2).
- **`pmat`** — `L4: pmat quality-gate` exits 127 in `lint-gate`.

Both are runner-side provisioning issues. The reusable workflow is pinned to `paiml/.github@b6c24635` and not editable from this repo. The workflow file's own header already documents:

> When the `paiml/infra` `_provision` target is fixed, this workflow goes green automatically — no change needed here.

## Change

Remove `push` and `pull_request_target` triggers; keep `workflow_dispatch` for manual re-test.

## Doesn't affect

- Required check `CI Status` (ci.yml) is unchanged and remains green
- Branch protection rules
- Lean Gate / Kani Gate / Quality Gate (stable) / manifest gates / recipe-table gate

## Test plan

- [x] Workflow file YAML parses (one-line trigger removal)
- [ ] After merge, next push to main has zero `Unified Gate (advisory)` runs
- [ ] `workflow_dispatch` still works manually

🤖 Generated with [Claude Code](https://claude.com/claude-code)